### PR TITLE
Adding SUFFIX_BIN/SUFFIX_LIB user settable cmake cache variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,10 +28,14 @@ option( BUILD_KTEST "A command line tool for testing single clBLAS kernel" ON )
 # However, test-correctness can instead use NETLIB as a reference library
 set(CORR_TEST_WITH_ACML ON CACHE BOOL "Use ACML library in correctness tests")
 
-# uncomment these to print compiler invocation lines for nmake files
-# set( CMAKE_START_TEMP_FILE "" )
-# set( CMAKE_END_TEMP_FILE "" )
-# set( CMAKE_VERBOSE_MAKEFILE 1 )
+if( CMAKE_GENERATOR MATCHES "NMake" )
+  option( NMAKE_COMPILE_VERBOSE "Print compile and link strings to the console" OFF )
+  if( NMAKE_COMPILE_VERBOSE )
+    set( CMAKE_START_TEMP_FILE "" )
+    set( CMAKE_END_TEMP_FILE "" )
+    set( CMAKE_VERBOSE_MAKEFILE 1 )
+  endif( )
+endif( )
 
 # If we are on linux, and we wish to link with the netlib BLAS implementation, we need to have a valid fortran compiler
 if( NOT CORR_TEST_WITH_ACML AND NOT WIN32)
@@ -66,15 +70,27 @@ if(NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif()
 
+# These variables are meant to contain string which should be appended to the installation paths 
+# of library and executable binaries, respectively.  They are meant to be user configurable/overridable.  
+set( SUFFIX_LIB_DEFAULT "" )
+set( SUFFIX_BIN_DEFAULT "" )
+
 if(TARGET_PLATFORM EQUAL 32 OR TARGET_PLATFORM EQUAL 64)
     set(TARGET_PLATFORM ${TARGET_PLATFORM} CACHE STRING "Target platform type (32-bit or 64-bit)" FORCE)
+    if( TARGET_PLATFORM EQUAL 64 )
+        set( SUFFIX_LIB_DEFAULT "64" )
+    endif( )
 else()
     if(CMAKE_SIZEOF_VOID_P MATCHES 8)
         set(TARGET_PLATFORM "64" CACHE STRING "Target platform type (32-bit or 64-bit)" FORCE)
+        set( SUFFIX_LIB_DEFAULT "64" )
     else()
         set(TARGET_PLATFORM "32" CACHE STRING "Target platform type (32-bit or 64-bit)" FORCE)
     endif()
 endif()
+
+set( SUFFIX_LIB ${SUFFIX_LIB_DEFAULT} CACHE STRING "String to append to 'lib' install path" )
+set( SUFFIX_BIN ${SUFFIX_BIN_DEFAULT} CACHE STRING "String to append to 'bin' install path" )
 
 if( MSVC_IDE )
     set_property( GLOBAL PROPERTY USE_FOLDERS TRUE )
@@ -202,11 +218,16 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     if(TARGET_PLATFORM EQUAL 32)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-builtin")
     endif()
-endif()
+elseif( MSVC )
+	# CMake sets huge stack frames for windows, for whatever reason.  We go with compiler default.
+	string( REGEX REPLACE "/STACK:[0-9]+" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}" )
+	string( REGEX REPLACE "/STACK:[0-9]+" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}" )
+	string( REGEX REPLACE "/STACK:[0-9]+" "" CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}" ) 
+endif( )
 
 if (WIN32)
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-endif()
+endif( )
 
 #TODO:  We should remove this pre-processor define for our 1.8 build; this means removing our deprecated image functions such as calls clCreateImage2D( )
 add_definitions( -DCL_USE_DEPRECATED_OPENCL_1_1_APIS )

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -52,17 +52,9 @@ target_link_libraries(client ${Boost_LIBRARIES} ${OPENCL_LIBRARIES} clBLAS)
 add_executable(testPerfWrapper ${WRAPPER_SRC})
 target_link_libraries(testPerfWrapper ${Boost_LIBRARIES})
 
-if( TARGET_PLATFORM EQUAL 64 )
-    set( BIN_DIR bin64 )
-    set( LIB_DIR lib64 )
-else()
-    set( BIN_DIR bin32 )
-    set( LIB_DIR lib32 )
-endif()
-
 # CPack configuration; include the executable into the package
 install( TARGETS client testPerfWrapper
-		RUNTIME DESTINATION ${BIN_DIR}
-		LIBRARY DESTINATION ${LIB_DIR}
-		ARCHIVE DESTINATION ${LIB_DIR}/import
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
 		)

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -289,7 +289,7 @@ set( tplgenBinaryDir "" )
 if( CMAKE_COMPILER_IS_GNUCXX )
     set( tplgenBinaryDir ${binary_dir} )
 else()
-    set( tplgenBinaryDir "${binary_dir}/Debug" )
+    set( tplgenBinaryDir "${binary_dir}/${CMAKE_CFG_INTDIR}" )
 endif()
 
 add_custom_target( GENERATE_CLT
@@ -305,18 +305,9 @@ set_target_properties(clBLAS PROPERTIES VERSION ${clBLAS_VERSION})
 set_target_properties(clBLAS PROPERTIES SOVERSION ${clBLAS_SOVERSION})
 target_link_libraries(clBLAS ${OPENCL_LIBRARIES} ${MATH_LIBRARY})
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS clBLAS
-			RUNTIME DESTINATION bin64
-			LIBRARY DESTINATION lib64
-			ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS clBLAS
-			RUNTIME DESTINATION bin32
-			LIBRARY DESTINATION lib32
-			ARCHIVE DESTINATION lib32/import
-			)
-endif()
+# CPack configuration; include the executable into the package
+install( TARGETS clBLAS
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+		)

--- a/src/library/blas/gens/legacy/tests/CMakeLists.txt
+++ b/src/library/blas/gens/legacy/tests/CMakeLists.txt
@@ -46,18 +46,9 @@ include_directories(${OPENCL_INCLUDE_DIRS} ${clBLAS_SOURCE_DIR} ${clBLAS_SOURCE_
 add_executable(t_blkmul ${SRC_BLKMUL})
 target_link_libraries(t_blkmul ${OPENCL_LIBRARIES})
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS t_blkmul
-			RUNTIME DESTINATION bin64
-			LIBRARY DESTINATION lib64
-			ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS t_blkmul
-			RUNTIME DESTINATION bin32
-			LIBRARY DESTINATION lib32
-			ARCHIVE DESTINATION lib32/import
-			)
-endif()
+# CPack configuration; include the executable into the package
+install( TARGETS t_blkmul
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+		)

--- a/src/library/blas/gens/tests/CMakeLists.txt
+++ b/src/library/blas/gens/tests/CMakeLists.txt
@@ -43,18 +43,9 @@ include_directories(${OPENCL_INCLUDE_DIRS} ${clBLAS_SOURCE_DIR} ${clBLAS_SOURCE_
 add_executable(t_tilemul ${SRC_TILEMUL})
 target_link_libraries(t_tilemul ${OPENCL_LIBRARIES})
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS t_tilemul
-			RUNTIME DESTINATION bin64
-			LIBRARY DESTINATION lib64
-			ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS t_tilemul
-			RUNTIME DESTINATION bin32
-			LIBRARY DESTINATION lib32
-			ARCHIVE DESTINATION lib32/import
-			)
-endif()
+# CPack configuration; include the executable into the package
+install( TARGETS t_tilemul
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+		)

--- a/src/library/common/tests/CMakeLists.txt
+++ b/src/library/common/tests/CMakeLists.txt
@@ -48,18 +48,9 @@ target_link_libraries(t_dblock_kgen ${OPENCL_LIBRARIES} ${MATH_LIBRARY})
 add_executable(t_gens_cache ${SRC_GENS_CACHE})
 target_link_libraries(t_gens_cache ${OPENCL_LIBRARIES} ${MATH_LIBRARY})
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS t_dblock_kgen t_gens_cache
-			RUNTIME DESTINATION bin64
-			LIBRARY DESTINATION lib64
-			ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS t_dblock_kgen t_gens_cache
-			RUNTIME DESTINATION bin32
-			LIBRARY DESTINATION lib32
-			ARCHIVE DESTINATION lib32/import
-			)
-endif()
+# CPack configuration; include the executable into the package
+install( TARGETS t_dblock_kgen t_gens_cache
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+		)

--- a/src/library/tools/ktest/CMakeLists.txt
+++ b/src/library/tools/ktest/CMakeLists.txt
@@ -141,18 +141,9 @@ add_executable(make-ktest ${KTEST_SRC} ${KTEST_EXTERNAL_SRC})
 add_dependencies(make-ktest GENERATE_CLT)
 target_link_libraries(make-ktest ${OPENCL_LIBRARIES} ${Boost_LIBRARIES} ${MATH_LIBRARY})
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS make-ktest
-			RUNTIME DESTINATION bin64
-			LIBRARY DESTINATION lib64
-			ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS make-ktest
-			RUNTIME DESTINATION bin32
-			LIBRARY DESTINATION lib32
-			ARCHIVE DESTINATION lib32/import
-			)
-endif()
+# CPack configuration; include the executable into the package
+install( TARGETS make-ktest
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+		)

--- a/src/library/tools/tune/CMakeLists.txt
+++ b/src/library/tools/tune/CMakeLists.txt
@@ -139,18 +139,9 @@ add_executable(tune ${TOOLS_SRC} ${TOOLS_EXTERNAL_SRC})
 add_dependencies(tune GENERATE_CLT)
 target_link_libraries(tune ${OPENCL_LIBRARIES} ${TIME_LIBRARY} ${MATH_LIBRARY})
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS tune
-			RUNTIME DESTINATION bin64
-			LIBRARY DESTINATION lib64
-			ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS tune
-			RUNTIME DESTINATION bin32
-			LIBRARY DESTINATION lib32
-			ARCHIVE DESTINATION lib32/import
-			)
-endif()
+# CPack configuration; include the executable into the package
+install( TARGETS tune
+		RUNTIME DESTINATION bin${SUFFIX_BIN}
+		LIBRARY DESTINATION lib${SUFFIX_LIB}
+		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+		)

--- a/src/samples/CMakeLists.txt
+++ b/src/samples/CMakeLists.txt
@@ -260,45 +260,24 @@ add_executable(example_sasum ${SASUM_SAMPLE_SRC})
 target_link_libraries(example_sasum ${OPENCL_LIBRARIES} clBLAS)
 set_property( TARGET example_sasum PROPERTY FOLDER "Samples")
 
-if( TARGET_PLATFORM EQUAL 64 )
-	# CPack configuration; include the executable into the package
-	install( TARGETS example_sgemm example_sgemv example_ssymv example_ssyrk
-             example_ssyr2k example_strmm example_strsm 
-		     example_strmv example_strsv example_sger example_cher example_ssyr 
-		     example_ssyr2 example_cherk example_ssymm example_chemm
-		     example_stpmv example_chpmv example_stpsv example_sspmv example_sspr example_chpr
-		     example_sspr2 example_zhpr2 
-		     example_sgbmv example_stbmv example_ssbmv example_chbmv example_stbsv
-		     example_cher2k
-		     example_sswap example_sscal example_csscal example_scopy example_saxpy example_sdot
-		     example_srotg example_srotmg example_srot example_srotm
-		     example_snrm2 example_sasum example_isamax
+# CPack configuration; include the executable into the package
+install( TARGETS example_sgemm example_sgemv example_ssymv example_ssyrk
+         example_ssyr2k example_strmm example_strsm 
+         example_strmv example_strsv example_sger example_cher example_ssyr 
+         example_ssyr2 example_cherk example_ssymm example_chemm
+         example_stpmv example_chpmv example_stpsv example_sspmv example_sspr example_chpr
+         example_sspr2 example_zhpr2 
+         example_sgbmv example_stbmv example_ssbmv example_chbmv example_stbsv
+         example_cher2k
+         example_sswap example_sscal example_csscal example_scopy example_saxpy example_sdot
+         example_srotg example_srotmg example_srot example_srotm
+         example_snrm2 example_sasum example_isamax
 
-			 version
-			 RUNTIME DESTINATION bin64
-			 LIBRARY DESTINATION lib64
-			 ARCHIVE DESTINATION lib64/import
-			)
-else()
-	# CPack configuration; include the executable into the package
-	install( TARGETS example_sgemm example_sgemv example_ssymv example_ssyrk
-             example_ssyr2k example_strmm example_strsm 
-		     example_strmv example_strsv example_sger example_cher example_ssyr 
-		     example_ssyr2 example_cherk example_ssymm example_chemm
-		     example_stpmv example_chpmv example_stpsv example_sspmv example_sspr example_chpr
-		     example_sspr2 example_zhpr2 
-		     example_sgbmv example_stbmv example_ssbmv example_chbmv example_stbsv
-		     example_cher2k
-		     example_sswap example_sscal example_csscal example_scopy example_saxpy example_sdot
-		     example_srotg example_srotmg example_srot example_srotm
-		     example_snrm2 example_sasum example_isamax
-
-			 version
-			 RUNTIME DESTINATION bin32
-			 LIBRARY DESTINATION lib32
-			 ARCHIVE DESTINATION lib32/import
-			)
-endif()
+         version
+        RUNTIME DESTINATION bin${SUFFIX_BIN}
+        LIBRARY DESTINATION lib${SUFFIX_LIB}
+        ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+        )
 
 configure_file( "${PROJECT_SOURCE_DIR}/samples/CMakeLists.pack"
 		"${PROJECT_BINARY_DIR}/samples/CMakeLists.txt" COPYONLY )

--- a/src/scripts/perf/CMakeLists.txt
+++ b/src/scripts/perf/CMakeLists.txt
@@ -21,10 +21,4 @@ set(GRAPHING_SCRIPTS 	measurePerformance.py
 						performanceUtility.py
 						)
 
-if( TARGET_PLATFORM EQUAL 64 )
-    set( BIN_DIR bin64 )
-else()
-    set( BIN_DIR bin32 )
-endif()
-
-install( FILES ${GRAPHING_SCRIPTS} DESTINATION ${BIN_DIR} )
+install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -276,11 +276,7 @@ endif()
 # It stitches together a path to a previously built static library, based on our 'make install' logic
 # Search for 64bit libs if FIND_LIBRARY_USE_LIB64_PATHS is set to true in the global environment, 32bit libs else
 get_property( LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS )
-if( LIB64 )
-	set( runtime.library "${CMAKE_INSTALL_PREFIX}/lib64" )
-else( )
-	set( runtime.library "${CMAKE_INSTALL_PREFIX}/lib32" )
-endif( )
+set( runtime.library "${CMAKE_INSTALL_PREFIX}/lib${SUFFIX_LIB}" )
 
 if( WIN32 )
 	set( runtime.library "${runtime.library}/import/clBLAS${CMAKE_STATIC_LIBRARY_SUFFIX}" )
@@ -371,22 +367,13 @@ if( GTEST_FOUND )
     set_property( TARGET test-medium PROPERTY FOLDER "Test")
     set_property( TARGET test-short PROPERTY FOLDER "Test")
 
-    if( TARGET_PLATFORM EQUAL 64 )
-	    # CPack configuration; include the executable into the package
-	    install( TARGETS test-correctness test-medium test-short
-			    RUNTIME DESTINATION bin64
-			    LIBRARY DESTINATION lib64
-			    ARCHIVE DESTINATION lib64/import
-			    )
-    else()
-	    # CPack configuration; include the executable into the package
-	    install( TARGETS test-correctness test-medium test-short
-			    RUNTIME DESTINATION bin32
-			    LIBRARY DESTINATION lib32
-			    ARCHIVE DESTINATION lib32/import
-			    )
-    endif()
-
+    # CPack configuration; include the executable into the package
+    install( TARGETS test-correctness test-medium test-short
+            RUNTIME DESTINATION bin${SUFFIX_BIN}
+            LIBRARY DESTINATION lib${SUFFIX_LIB}
+            ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+            )
+    
 	if( ACML_FOUND )
 		include_directories(${OPENCL_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS}
 			${clBLAS_SOURCE_DIR} ${clBLAS_SOURCE_DIR}/tests/include  ${clBLAS_SOURCE_DIR}/include)
@@ -407,21 +394,12 @@ if( GTEST_FOUND )
 
         set_property( TARGET test-performance PROPERTY FOLDER "Test")
 
-		if( TARGET_PLATFORM EQUAL 64 )
-			# CPack configuration; include the executable into the package
-			install( TARGETS test-performance
-					RUNTIME DESTINATION bin64
-					LIBRARY DESTINATION lib64
-					ARCHIVE DESTINATION lib64/import
-					)
-		else()
-			# CPack configuration; include the executable into the package
-			install( TARGETS test-performance
-					RUNTIME DESTINATION bin32
-					LIBRARY DESTINATION lib32
-					ARCHIVE DESTINATION lib32/import
-					)
-		endif()
+        # CPack configuration; include the executable into the package
+        install( TARGETS test-performance
+                RUNTIME DESTINATION bin${SUFFIX_BIN}
+                LIBRARY DESTINATION lib${SUFFIX_LIB}
+                ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+                )
 	endif()
 
 	include_directories(${OPENCL_INCLUDE_DIRS} ${GTEST_INCLUDE_DIRS}
@@ -438,19 +416,10 @@ if( GTEST_FOUND )
 
     set_property( TARGET test-functional PROPERTY FOLDER "Test")
 
-	if( TARGET_PLATFORM EQUAL 64 )
-		# CPack configuration; include the executable into the package
-		install( TARGETS test-functional
-				RUNTIME DESTINATION bin64
-				LIBRARY DESTINATION lib64
-				ARCHIVE DESTINATION lib64/import
-				)
-	else()
-		# CPack configuration; include the executable into the package
-		install( TARGETS test-functional
-				RUNTIME DESTINATION bin32
-				LIBRARY DESTINATION lib32
-				ARCHIVE DESTINATION lib32/import
-				)
-	endif()
+    # CPack configuration; include the executable into the package
+    install( TARGETS test-functional
+            RUNTIME DESTINATION bin${SUFFIX_BIN}
+            LIBRARY DESTINATION lib${SUFFIX_LIB}
+            ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
+            )
 endif()


### PR DESCRIPTION
Fixed a bug wherein the build would fail if a release build were built before debug build
Removing /stack from windows builds; adding printscreen support for nmake builds
Changing install suffixes based upon user settable cmake cache variables: SUFFIX_BIN/SUFFIX_LIB
