### PR TITLE
fix a bug in 32 bit linux build linking to pthread

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -409,7 +409,7 @@ if( GTEST_FOUND )
 								  ${FUNC_HEADERS} ${TESTS_HEADERS})
 								  
 	if( BUILD_RUNTIME )
-		target_link_libraries(test-functional ${GTEST_LIBRARIES} ${TIME_LIBRARY} clBLAS)
+		target_link_libraries(test-functional ${GTEST_LIBRARIES} ${TIME_LIBRARY} ${THREAD_LIBRARY} clBLAS)
 	else()
 		target_link_libraries(test-functional ${GTEST_LIBRARIES} ${TIME_LIBRARY} ${THREAD_LIBRARY} ${OPENCL_LIBRARIES} ${runtime.library} )
 	endif()


### PR DESCRIPTION
In 32 bit build on linux compiler complains not linked to pthread. This pull request should fix this problem and does not affect the 64 bit build or windows build. 
