### PR TITLE
Only estimate kernel source size if we actually have the kernel source

### DIFF
--- a/src/include/kern_cache.h
+++ b/src/include/kern_cache.h
@@ -55,6 +55,7 @@ typedef struct Kernel {
     void *extra;
     size_t extraSize;
     void (*dtor)(struct Kernel *kern);
+    int noSource;
 } Kernel;
 
 typedef int

--- a/src/library/blas/generic/common.c
+++ b/src/library/blas/generic/common.c
@@ -364,6 +364,7 @@ Kernel VISIBILITY_HIDDEN
         kernel->extra = calloc(1, kernel->extraSize);
         *(CLBLASKernExtra*)(kernel->extra) = *extra;
         kernel->dtor = extraDtor;
+        kernel->noSource = 1;
     }
     else {
         putKernel(NULL, kernel);
@@ -491,6 +492,7 @@ Kernel
 #if !defined(KEEP_CLBLAS_KERNEL_SOURCES)
     if (err == CL_SUCCESS) {
         err = dropProgramSource(&kernel->program, context, device);
+        kernel->noSource = 1;
     }
 #endif  /* !DUMP_CLBLAS_KERNELS */
 

--- a/src/library/common/kern_cache.c
+++ b/src/library/common/kern_cache.c
@@ -425,7 +425,9 @@ fullKernelSize(Kernel *kern)
         size += allSizes[i];
     }
 
-    clGetProgramInfo(kern->program, CL_PROGRAM_SOURCE, 0, NULL, &retSize);
+    if (!kern->noSource) {
+        clGetProgramInfo(kern->program, CL_PROGRAM_SOURCE, 0, NULL, &retSize);
+    }
 
     return (size + retSize + sizeof(Kernel) + kern->extraSize);
 }


### PR DESCRIPTION
See issue #21 for the discussion why this seems necessary under OSX.
