### PR TITLE
fix bug in ssyrk, now use only uint for mad24

### DIFF
--- a/src/library/blas/gens/syrxk.c
+++ b/src/library/blas/gens/syrxk.c
@@ -1401,7 +1401,7 @@ genUpdateGenericDiagTile(
                                 "cc%u = ((%s)mask &\n"
                                 "       %s) >>\n"
                                 "      %s;\n"
-                                "cc%u = %u - mad24(cc%u, %s, 0);\n",
+                                "cc%u = %u - mad24(cc%u, %s, 0u);\n",
 
                                 iter.row,
                                 (1 << (nrCols - 1)),
@@ -1416,7 +1416,7 @@ genUpdateGenericDiagTile(
                                 "cc%u = ((%s)mask &\n"
                                 "       %s) >>\n"
                                 "      %s;\n"
-                                "cc%u = mad24(cc%u, %s, 0);\n",
+                                "cc%u = mad24(cc%u, %s, 0u);\n",
 
                                 nrRows - 1, iter.row,
                                 i, vctype.buf, constMasks.buf, constShifts.buf,


### PR DESCRIPTION
The problem is only visible if we tune syrk for single precision.
mad24 uses the wrong argument type (uint, uint, int) instead of (uint, uint, uint)
