### PR TITLE
A fix for an uninitialized variable in the tune tool

### DIFF
--- a/src/include/trace_malloc.h
+++ b/src/include/trace_malloc.h
@@ -48,7 +48,7 @@ void releaseMallocTrace(void);
 
 static __inline void initMallocTrace(void)
 {
-    /* do noting */
+    /* do nothing */
 }
 
 static __inline void printMallocStatistics(void)


### PR DESCRIPTION
The problem would manifest itself when the --store-kernels flag was used on the command line.
Comments were added to clarify a few sections of code.
Fixes #5
Fixes #6
