### PR TITLE
Allow specifying the device to use for testing via its device id

### DIFF
--- a/src/tests/BlasBase.cpp
+++ b/src/tests/BlasBase.cpp
@@ -496,6 +496,7 @@ BlasBase::printEnvInfo(void)
             break;
         }
 
+        std::cout << "Device id" << ": " << (i ? additionalDevice_ : primaryDevice_) << std::endl;
         printDevInfoStr(CL_DEVICE_NAME, "Device name", i);
         printDevInfoStr(CL_DEVICE_VENDOR, "Device vendor", i);
         std::cout << "Platform (bit): ";

--- a/src/tests/BlasBase.cpp
+++ b/src/tests/BlasBase.cpp
@@ -162,6 +162,7 @@ BlasBase::getDevice(cl_device_type type, const char* name,
         }
 
         for (i = 0; i < nrDevices; i++) {
+            char devid_name[255];
             err = clGetDeviceInfo(devices[i], devInfo, 0, NULL, &sz);
             if (err != CL_SUCCESS) {
                 continue;
@@ -180,7 +181,9 @@ BlasBase::getDevice(cl_device_type type, const char* name,
                 selPlatform = platform;
             }
                 printf("---- %s\n", str);
-            if (strcmp(str, name) == 0) {
+                snprintf(devid_name, sizeof(devid_name), "%p", devices[i]);
+
+            if (strcmp(str, name) == 0 || strcmp(devid_name, name) == 0) {
                 //printf("---- %s\n", str);
                 platform_ = platform;
                 result = devices[i];


### PR DESCRIPTION
On my machine (MacPro late 2013) there are two FirePro D300
cards. With this patch one can see which one was used and it
also allows one to call the test program with a specific device
id to choose which one of the two to use, e.g. --device "0x2021c00"
(sine they have exactly the same name, the name itself cannot
be used to select one of them).

