### PR TITLE
s/CMAKE_SOURCE_DIR/PROJECT_SOURCE_DIR/ in library/CMakeLists.txt.

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -279,7 +279,7 @@ endif()
 
 include( ExternalProject )
 ExternalProject_Add( tplgen
-    URL "${CMAKE_SOURCE_DIR}/library/tools/tplgen"
+    URL "${PROJECT_SOURCE_DIR}/library/tools/tplgen"
     INSTALL_COMMAND ""
 )
 
@@ -294,7 +294,7 @@ endif()
 
 add_custom_target( GENERATE_CLT
     COMMAND ${tplgenBinaryDir}/tplgen -o ${clBLAS_BINARY_DIR}/include ${SRC_CL_TEMPLATES}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/library/blas/gens/clTemplates
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/library/blas/gens/clTemplates
 )
 
 add_dependencies( GENERATE_CLT tplgen )


### PR DESCRIPTION
Do so to allow another parent CMake project to be able to successfully
call add_subdirectory(clBLAS) on this one.
