### PR TITLE
fixed FindOpenCL.cmake file to find OpenCL on Ubuntu 14.04 with CUDA 6.0

### DIFF
--- a/src/FindOpenCL.cmake
+++ b/src/FindOpenCL.cmake
@@ -56,6 +56,8 @@ find_path(OPENCL_INCLUDE_DIRS
     PATHS
         /usr/include
         /usr/local/include
+        /usr/local/cuda/include
+        /opt/cuda/include
     DOC "OpenCL header file path"
 )
 mark_as_advanced( OPENCL_INCLUDE_DIRS )
@@ -74,6 +76,8 @@ if( LIB64 )
         PATH_SUFFIXES x86_64 x64
         PATHS
             /usr/lib
+            /usr/local/cuda/lib
+            /opt/cuda/lib
     )
 else( )
     find_library( OPENCL_LIBRARIES
@@ -86,6 +90,8 @@ else( )
         PATH_SUFFIXES x86 Win32
         PATHS
             /usr/lib
+            /usr/local/cuda/lib
+            /opt/cuda/lib
     )
 endif( )
 mark_as_advanced( OPENCL_LIBRARIES )


### PR DESCRIPTION
OpenCL is not found on Ubuntu 14.04 with a default CUDA install. I added a few path hints that should solve this problem.