### PR TITLE
Always cast get_*_* to uints before casting to vectors.

### DIFF
--- a/src/library/blas/gens/gemm.c
+++ b/src/library/blas/gens/gemm.c
@@ -560,7 +560,7 @@ blockGen(
         kgenAddStmt(ctx, tmp);
     }
     else {
-        sprintf(globalIdB, "get_global_id(%d)", 1-i);
+        sprintf(globalIdB, "(uint)get_global_id(%d)", 1-i);
     }
 
     if (!(isColMajA || isColMajB)) {
@@ -758,7 +758,7 @@ subgGen(
     vecLenA = gset.tileA.vecLen;
 
     // channel offset based coordinate
-    ksprintf(&exprK, "( get_group_id(0)*%lu + k )", staggered/vecLenA*vecLenA);
+    ksprintf(&exprK, "( (uint)(get_group_id(0))*%lu + k )", staggered/vecLenA*vecLenA);
 
     // starting code generation--------------------------------------------------
     pCtx = createKgenContext(pBuf, buflen, true);


### PR DESCRIPTION
- Fixes issues with on intel SDKs on Windows, Apple SDKs on OSX
- Fixes #62 