### PR TITLE
install clBLAS cmake configuration and version file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -297,6 +297,26 @@ if( BUILD_TEST )
 	endif( )
 endif( )
 
+if(WIN32)
+  set(destdir CMake)
+else()
+  set(destdir share/clBLAS)
+endif()
+string(REGEX REPLACE "[^/]+" ".." reldir "${destdir}")
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/clBLASConfigVersion.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/clBLASConfigVersion.cmake
+  @ONLY)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/clBLASConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/clBLASConfig.cmake
+  @ONLY)
+install(EXPORT Library DESTINATION ${destdir} FILE clBLASTargets.cmake)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/clBLASConfigVersion.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/clBLASConfig.cmake
+  DESTINATION ${destdir})
+
+
 # The following code is setting variables to control the behavior of CPack to generate our 
 if( WIN32 )
 	set( CPACK_SOURCE_GENERATOR "ZIP" )

--- a/src/clBLASConfig.cmake.in
+++ b/src/clBLASConfig.cmake.in
@@ -1,0 +1,3 @@
+include(${CMAKE_CURRENT_LIST_DIR}/clBLASTargets.cmake)
+get_filename_component(CLBLAS_INCLUDE_DIRS ${CMAKE_CURRENT_LIST_DIR}/@reldir@/include ABSOLUTE)
+set(CLBLAS_LIBRARIES clBLAS)

--- a/src/clBLASConfigVersion.cmake.in
+++ b/src/clBLASConfigVersion.cmake.in
@@ -1,0 +1,46 @@
+# This is a basic version file for the Config-mode of find_package().
+# It is used by write_basic_package_version_file() as input file for configure_file()
+# to create a version-file which can be installed along a config.cmake file.
+#
+# The created file sets PACKAGE_VERSION_EXACT if the current version string and
+# the requested version string are exactly the same and it sets
+# PACKAGE_VERSION_COMPATIBLE if the current version is >= requested version,
+# but only if the requested major version is the same as the current one.
+# The variable CLBLAS_VERSION must be set before calling configure_file().
+
+
+set(PACKAGE_VERSION "@CLBLAS_VERSION@")
+
+if("${PACKAGE_VERSION}" VERSION_LESS "${PACKAGE_FIND_VERSION}" )
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+
+  if("@CLBLAS_VERSION@" MATCHES "^([0-9]+)\\.")
+    set(CLBLAS_VERSION_MAJOR "${CMAKE_MATCH_1}")
+  else()
+    set(CLBLAS_VERSION_MAJOR "@CLBLAS_VERSION@")
+  endif()
+
+  if("${PACKAGE_FIND_VERSION_MAJOR}" STREQUAL "${CLBLAS_VERSION_MAJOR}")
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  endif()
+
+  if( "${PACKAGE_FIND_VERSION}" STREQUAL "${PACKAGE_VERSION}")
+      set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()
+
+
+# if the installed or the using project don't have CMAKE_SIZEOF_VOID_P set, ignore it:
+if("${CMAKE_SIZEOF_VOID_P}"  STREQUAL ""  OR "@CMAKE_SIZEOF_VOID_P@" STREQUAL "")
+   return()
+endif()
+
+# check that the installed version has the same 32/64bit-ness as the one which is currently searching:
+if(NOT "${CMAKE_SIZEOF_VOID_P}" STREQUAL "@CMAKE_SIZEOF_VOID_P@")
+  math(EXPR installedBits "@CMAKE_SIZEOF_VOID_P@ * 8")
+  set(PACKAGE_VERSION "${PACKAGE_VERSION} (${installedBits}bit)")
+  set(PACKAGE_VERSION_UNSUITABLE TRUE)
+endif()

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -316,8 +316,9 @@ target_link_libraries(clBLAS ${OPENCL_LIBRARIES} ${MATH_LIBRARY})
 
 # CPack configuration; include the executable into the package
 install( TARGETS clBLAS
-		RUNTIME DESTINATION bin${SUFFIX_BIN}
-		LIBRARY DESTINATION lib${SUFFIX_LIB}
+                EXPORT Library
+                RUNTIME DESTINATION bin${SUFFIX_BIN}
+                LIBRARY DESTINATION lib${SUFFIX_LIB}
 		ARCHIVE DESTINATION lib${SUFFIX_LIB}/import
 		)
 


### PR DESCRIPTION
so clBLAS can be used in a cmake project with the usual find_package command

  find_package(clBLAS REQUIRED)
  include_directories(${CLBLAS_INCLUDE_DIRS})
  tarkget_link_libraries(mytarget ${CLBLAS_LIBRARIES})