### PR TITLE
Install scripts/perf to share/clBLAS on non WIN32 systems

### DIFF
--- a/src/scripts/perf/CMakeLists.txt
+++ b/src/scripts/perf/CMakeLists.txt
@@ -21,4 +21,8 @@ set(GRAPHING_SCRIPTS 	measurePerformance.py
 						performanceUtility.py
 						)
 
-install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
+if( WIN32 )
+		install( FILES ${GRAPHING_SCRIPTS} DESTINATION bin${SUFFIX_BIN} )
+else ( )
+		install( FILES ${GRAPHING_SCRIPTS} DESTINATION share/clBLAS )
+endif( )


### PR DESCRIPTION
Python scripts should not get installed to `/usr/bin`. Same as for clFFT https://github.com/clMathLibraries/clFFT/pull/52.