### PR TITLE
added test for OSX detection to turn

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,13 @@ message( STATUS "You have confirmed OpenCL ${OCL_VERSION} is supported in your s
 
 # By default test-correctness is linked and tested against ACML library.
 # However, test-correctness can instead use NETLIB as a reference library
-set(CORR_TEST_WITH_ACML ON CACHE BOOL "Use ACML library in correctness tests")
+# On Mac OSX systems, this must be set to OFF for the build to succeed (due to nesting of FindBLAS code)
+if ( APPLE )
+	set(CORR_TEST_WITH_ACML OFF CACHE BOOL "Use ACML library in correctness tests")
+else ( )
+	message(STATUS "CORR_TEST_WITH_ACML set to ON")
+	set(CORR_TEST_WITH_ACML ON CACHE BOOL "Use ACML library in correctness tests")
+endif( )
 
 if( CMAKE_GENERATOR MATCHES "NMake" )
   option( NMAKE_COMPILE_VERBOSE "Print compile and link strings to the console" OFF )
@@ -183,13 +189,13 @@ endif()
 # TODO: maybe this could be written using the FindBLAS module in the future
 if( BUILD_TEST )
 	if(NOT CORR_TEST_WITH_ACML)
-	        if(APPLE)
-			find_library(BLAS_LIBRARIES Accelerate)
+	    if(APPLE)
+			find_library(BLAS_LIBRARIES Accelerate HINTS /System/Library/Frameworks/Accelerate.framework)
 		       	MARK_AS_ADVANCED(BLAS_LIBRARIES)
 		       	message(STATUS "Using Accelerate framework on Mac OS-X")
-	       	else()
+	    else()
 			find_package( Netlib COMPONENTS BLAS REQUIRED )
-              	endif()
+        endif()
 	else( )
 		# Find ACML BLAS implementation
 		# platform dependent ACML subdirectory


### PR DESCRIPTION
[C.f #92] changed the CMakeLists.txt file BUILD_TEST block to increase readability, fix broken build on OSX systems.

refactored CMakeLists.txt in BUILD_TEST block
added test for OSX detection to turn off CORR_TEST_WITH_ACML

fyi: CMake generates a makefile which builds fine on my OSX machine.