### PR TITLE
Install cmake configuration to lib/cmake/clBLAS

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -300,7 +300,7 @@ endif( )
 if(WIN32)
   set(destdir CMake)
 else()
-  set(destdir share/clBLAS)
+  set(destdir lib${SUFFIX_LIB}/cmake/clBLAS)
 endif()
 string(REGEX REPLACE "[^/]+" ".." reldir "${destdir}")
 configure_file(


### PR DESCRIPTION
The cmake configuration should go to /usr/lib{64}/cmake/clBLAS and not to /usr/share/clBLAS. Similar to https://github.com/clMathLibraries/clFFT/pull/88.