### PR TITLE
Fix kernel crash on nvidia, caused by float4 alignement error

### DIFF
--- a/src/library/blas/gens/clTemplates/ger.cl
+++ b/src/library/blas/gens/clTemplates/ger.cl
@@ -52,7 +52,8 @@ __kernel void %PREFIXger_C_kernel( __global %TYPE const* restrict _X, __global %
 	}
 
 	// create local memory
-	__local %TYPE localX[ BH * %V ];
+  __local %TYPE%V localXV[ BH ];
+  __local %TYPE *localX = (__local %TYPE *)localXV;
 	__local %TYPE localY[ BW ];
 
 	uint lID = get_local_id( 0 );
@@ -193,7 +194,8 @@ __kernel void %PREFIXger_R_kernel( __global %TYPE const* restrict _X, __global %
 	}
 
     __local %TYPE localX[ BH ];
-    __local %TYPE localY[ BW * %V ];
+    __local %TYPE%V localYV[ BW ];
+    __local %TYPE *localY = (__local %TYPE *)localYV;
 
     uint lID = get_local_id( 0 );
     uint gID = get_group_id( 0 );


### PR DESCRIPTION
Fix kernel crash on nvidia, caused by float4 alignement error, see https://github.com/clMathLibraries/clBLAS/issues/108 for more details.

Excuse my forking off 'master', but 'develop' didnt build for me.

I reckon this alignment issue potentially might be behind a bunch of exisitng issue reports for both nvidia and intel potentially.  I suspect it might generalize to some other kernels too plausibly.
