### PR TITLE
add x86_64/sdk suffix as search location for libOpenCL.so

### DIFF
--- a/src/FindOpenCL.cmake
+++ b/src/FindOpenCL.cmake
@@ -73,7 +73,7 @@ if( LIB64 )
             $ENV{AMDAPPSDKROOT}/lib
             $ENV{CUDA_PATH}/lib
         DOC "OpenCL dynamic library path"
-        PATH_SUFFIXES x86_64 x64
+        PATH_SUFFIXES x86_64 x64 x86_64/sdk
         PATHS
             /usr/lib
             /usr/local/cuda/lib
@@ -88,6 +88,7 @@ else( )
             $ENV{CUDA_PATH}/lib
         DOC "OpenCL dynamic library path"
         PATH_SUFFIXES x86 Win32
+        
         PATHS
             /usr/lib
             /usr/local/cuda/lib


### PR DESCRIPTION
This is used by AMDAPPSDK v3.