### PR TITLE
SYMM error-check order and removal of debug printf statements

### DIFF
--- a/src/library/blas/ixamax.c
+++ b/src/library/blas/ixamax.c
@@ -56,23 +56,31 @@ doiAmax(
 
 		retCode = checkMemObjects(X, scratchBuf, iMax, true, X_VEC_ERRSET, A_MAT_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_iAMAX
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET ))) {
-			printf("Invalid Size for X\n");
+			#ifdef DEBUG_iAMAX
+            printf("Invalid Size for X\n");
+            #endif
             return retCode;
 		}
 		// Minimum size of scratchBuff is 2 * N
 		if ((retCode = checkVectorSizes(kargs->dtype, (2 * N), scratchBuf, 0, 1, A_MAT_ERRSET ))) {
-			printf("Insufficient ScratchBuff A\n");
+			#ifdef DEBUG_iAMAX
+            printf("Insufficient ScratchBuff A\n");
+            #endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(TYPE_UNSIGNED_INT, 1, iMax, offiMax, 1, X_VEC_ERRSET ))) {
-			printf("Invalid Size for iX\n");
+			#ifdef DEBUG_iAMAX
+            printf("Invalid Size for iX\n");
+            #endif
             return retCode;
 	    }
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xasum.c
+++ b/src/library/blas/xasum.c
@@ -59,24 +59,32 @@ doAsum(
 
 		retCode = checkMemObjects(scratchBuff, asum, X, true, X_VEC_ERRSET, X_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_ASUM
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET ))) {
-			printf("Invalid Size for X\n");
+			#ifdef DEBUG_ASUM
+            printf("Invalid Size for X\n");
+            #endif
             return retCode;
 		}
 		// Minimum size of scratchBuff is N
 		if ((retCode = checkVectorSizes(kargs->dtype, N, scratchBuff, 0, 1, X_VEC_ERRSET ))) {
-			printf("Insufficient ScratchBuff\n");
+			#ifdef DEBUG_ASUM
+            printf("Insufficient ScratchBuff\n");
+            #endif
             return retCode;
 		}
 
 		if ((retCode = checkVectorSizes(asumType, 1, asum, offAsum, 1, X_VEC_ERRSET ))) {
-			printf("Invalid Size for asum\n");
+			#ifdef DEBUG_ASUM
+            printf("Invalid Size for asum\n");
+            #endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xaxpy.c
+++ b/src/library/blas/xaxpy.c
@@ -54,18 +54,24 @@ doAxpy(
 
         retCode = checkMemObjects(X, Y, X, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
+			#ifdef DEBUG_AXPY
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+			#ifdef DEBUG_AXPY
 			printf("Invalid Size for X\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_AXPY
 			printf("Invalid Size for Y\n");
+			#endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xcopy.c
+++ b/src/library/blas/xcopy.c
@@ -54,18 +54,24 @@ doCopy(
 
         retCode = checkMemObjects(X, Y, X, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
+			#ifdef DEBUG_COPY
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+			#ifdef DEBUG_COPY
 			printf("Invalid Size for X\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_COPY
 			printf("Invalid Size for Y\n");
+			#endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xdot.c
+++ b/src/library/blas/xdot.c
@@ -61,27 +61,37 @@ doDot(
 		retCode = checkMemObjects(X, Y, X, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		retCode |= checkMemObjects(scratchBuff, dotProduct, X, false, X_VEC_ERRSET, X_VEC_ERRSET, Y_VEC_ERRSET );
 		if (retCode) {
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_DOT
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
-			printf("Invalid Size for X\n");
+			#ifdef DEBUG_DOT
+            printf("Invalid Size for X\n");
+            #endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
-			printf("Invalid Size for Y\n");
+			#ifdef DEBUG_DOT
+            printf("Invalid Size for Y\n");
+            #endif
             return retCode;
 		}
 		// Minimum size of scratchBuff is N
 		if ((retCode = checkVectorSizes(kargs->dtype, N, scratchBuff, 0, 1, X_VEC_ERRSET))) {
-			printf("Insufficient ScratchBuff\n");
+			#ifdef DEBUG_DOT
+            printf("Insufficient ScratchBuff\n");
+            #endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, dotProduct, offDP, 1, Y_VEC_ERRSET))) {
-			printf("Invalid Size for dotProduct\n");
+			#ifdef DEBUG_DOT
+            printf("Invalid Size for dotProduct\n");
+            #endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xger.c
+++ b/src/library/blas/xger.c
@@ -59,7 +59,9 @@ doGer(
 		/* Validate arguments */
 
 		if ((retCode = checkMemObjects(A, X, Y, true, A_MAT_ERRSET, X_VEC_ERRSET, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_GER
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 
@@ -67,15 +69,21 @@ doGer(
 
 		if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, A, offa, lda, A_MAT_ERRSET))) {
 
+			#ifdef DEBUG_GER
 			printf("Invalid Size for A %d\n",retCode );
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, M, X, offx, incx, X_VEC_ERRSET))) {
+			#ifdef DEBUG_GER
 			printf("Invalid Size for X\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_GER
 			printf("Invalid Size for Y\n");
+			#endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xher.c
+++ b/src/library/blas/xher.c
@@ -57,16 +57,22 @@ doher(
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, X, 0, false, A_MAT_ERRSET, X_VEC_ERRSET, END_ERRSET))) {
-   		printf("Invalid mem object..\n");
+   		#ifdef DEBUG_HER
+        printf("Invalid mem object..\n");
+        #endif
         return retCode;
     }
 
     if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, N, N, A, offa, lda, A_MAT_ERRSET))) {
+        #ifdef DEBUG_HER
         printf("Invalid Size for A\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+        #ifdef DEBUG_HER
         printf("Invalid Size for X\n");
+        #endif
         return retCode;
     }
 

--- a/src/library/blas/xher2.c
+++ b/src/library/blas/xher2.c
@@ -60,21 +60,29 @@ doHer2(
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, X, Y, true, A_MAT_ERRSET, X_VEC_ERRSET, Y_VEC_ERRSET))) {
+        #ifdef DEBUG_HER2
         printf("Invalid mem object..\n");
+        #endif
         return retCode;
     }
 
     if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, N, N, A, offa, lda, A_MAT_ERRSET))) {
+        #ifdef DEBUG_HER2
         printf("Invalid Size for A\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+        #ifdef DEBUG_HER2
         printf("Invalid Size for X\n");
+        #endif
         return retCode;
     }
 
 	if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+        #ifdef DEBUG_HER2
         printf("Invalid Size for Y\n");
+        #endif
         return retCode;
     }
 

--- a/src/library/blas/xrot.c
+++ b/src/library/blas/xrot.c
@@ -52,18 +52,24 @@ doRot(
 
         retCode = checkMemObjects(X, Y, X, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_ROT
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
-			printf("Invalid Size for X\n");
+			#ifdef DEBUG_ROT
+            printf("Invalid Size for X\n");
+            #endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
-			printf("Invalid Size for Y\n");
+			#ifdef DEBUG_ROT
+            printf("Invalid Size for Y\n");
+            #endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xrotg.c
+++ b/src/library/blas/xrotg.c
@@ -58,33 +58,45 @@ doRotg(
 
         retCode = checkMemObjects(A, B, A, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {      // for mem objects A, B
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_ROTG
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 		retCode = checkMemObjects(C, S, C, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {      // for mem objects C, S
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_ROTG
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, A, offA, 1, X_VEC_ERRSET))) {
-			printf("Invalid Size for A\n");
+			#ifdef DEBUG_ROTG
+            printf("Invalid Size for A\n");
+            #endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, B, offB, 1, Y_VEC_ERRSET))) {
-			printf("Invalid Size for B\n");
+			#ifdef DEBUG_ROTG
+            printf("Invalid Size for B\n");
+            #endif
             return retCode;
 		}
 
 		if ((retCode = checkVectorSizes(cType, 1, C, offC, 1, X_VEC_ERRSET))) {
-			printf("Invalid Size for C\n");
+			#ifdef DEBUG_ROTG
+            printf("Invalid Size for C\n");
+            #endif
             return retCode;
 		}
 
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, S, offS, 1, Y_VEC_ERRSET))) {
-			printf("Invalid Size for S\n");
+			#ifdef DEBUG_ROTG
+            printf("Invalid Size for S\n");
+            #endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xrotm.c
+++ b/src/library/blas/xrotm.c
@@ -54,22 +54,30 @@ doRotm(
 
         retCode = checkMemObjects(X, Y, param, true, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
+			#ifdef DEBUG_ROTM
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTM
 			printf("Invalid Size for X\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTM
 			printf("Invalid Size for Y\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 5, param, offParam, 1, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTM
 			printf("Invalid Size for PARAM\n"); // PARAM is of minimum length 5
+			#endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xrotmg.c
+++ b/src/library/blas/xrotmg.c
@@ -54,35 +54,49 @@ doRotmg(
 
         retCode = checkMemObjects(D1, D2, X1, true, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {      // for mem objects A, B
+			#ifdef DEBUG_ROTMG
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 		retCode = checkMemObjects(Y1, param, Y1, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {      // for mem objects C, S
+			#ifdef DEBUG_ROTMG
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, D1, offD1, 1, X_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTMG
 			printf("Invalid Size for D1\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, D2, offD2, 1, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTMG
 			printf("Invalid Size for D2\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, X1, offX1, 1, X_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTMG
 			printf("Invalid Size for X1\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, Y1, offY1, 1, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTMG
 			printf("Invalid Size for Y1\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, 1, param, offParam, 1, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_ROTMG
 			printf("Invalid Size for PARAM\n");
+			#endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xscal.c
+++ b/src/library/blas/xscal.c
@@ -51,14 +51,18 @@ doScal(
 
         retCode = checkMemObjects(X, X, X, false, X_VEC_ERRSET, X_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
-			printf("Invalid mem object..\n");
+			#ifdef DEBUG_SCAL
+            printf("Invalid mem object..\n");
+            #endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
-			printf("Invalid Size for X\n");
+			#ifdef DEBUG_SCAL
+            printf("Invalid Size for X\n");
+            #endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xswap.c
+++ b/src/library/blas/xswap.c
@@ -54,18 +54,24 @@ doSwap(
 
         retCode = checkMemObjects(X, Y, X, false, X_VEC_ERRSET, Y_VEC_ERRSET, X_VEC_ERRSET );
 		if (retCode) {
+			#ifdef DEBUG_SWAP
 			printf("Invalid mem object..\n");
+			#endif
             return retCode;
 		}
 
 		// Check wheather enough memory was allocated
 
 		if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+			#ifdef DEBUG_SWAP
 			printf("Invalid Size for X\n");
+			#endif
             return retCode;
 		}
 		if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+			#ifdef DEBUG_SWAP
 			printf("Invalid Size for Y\n");
+			#endif
             return retCode;
 		}
 		///////////////////////////////////////////////////////////////

--- a/src/library/blas/xsymm.c
+++ b/src/library/blas/xsymm.c
@@ -54,14 +54,6 @@ doSymm(	CLBlasKargs *kargs, clblasOrder order, clblasUplo uplo, clblasSide side,
         return retCode;
     }
 
-
-    if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, B, offb, ldb, B_MAT_ERRSET))) {
-        return retCode;
-    }
-
-    if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, C, offc, ldc, C_MAT_ERRSET))) {
-        return retCode;
-    }
 	if (side == clblasLeft)
 	{
 		// MxM x MxN
@@ -74,6 +66,12 @@ doSymm(	CLBlasKargs *kargs, clblasOrder order, clblasUplo uplo, clblasSide side,
             return retCode;
     	}
 	}
+    if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, B, offb, ldb, B_MAT_ERRSET))) {
+        return retCode;
+    }
+    if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, C, offc, ldc, C_MAT_ERRSET))) {
+        return retCode;
+    }
 
 	#ifdef DEBUG_SYMM
 	printf("DoSymm being called...\n");

--- a/src/library/blas/xsymm.c
+++ b/src/library/blas/xsymm.c
@@ -51,31 +51,26 @@ doSymm(	CLBlasKargs *kargs, clblasOrder order, clblasUplo uplo, clblasSide side,
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, B, C, true, A_MAT_ERRSET, B_MAT_ERRSET, C_MAT_ERRSET))) {
-		printf("SYMM:- Invalid mem object..\n");
         return retCode;
     }
 
 
     if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, B, offb, ldb, B_MAT_ERRSET))) {
-		printf("Invalid Size for B\n");
         return retCode;
     }
 
     if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, N, C, offc, ldc, C_MAT_ERRSET))) {
-		printf("Invalid Size for C\n");
         return retCode;
     }
 	if (side == clblasLeft)
 	{
 		// MxM x MxN
     	if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, M, M, A, offa, lda, A_MAT_ERRSET))) {
-			printf("Invalid Size for A\n");
             return retCode;
     	}
 	} else {
 		// MxN x NxN
     	if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, N, N, A, offa, lda, A_MAT_ERRSET))) {
-			printf("Invalid Size for A\n");
             return retCode;
     	}
 	}

--- a/src/library/blas/xsyr.c
+++ b/src/library/blas/xsyr.c
@@ -56,7 +56,9 @@ doSyr(
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, X, 0, false, A_MAT_ERRSET, X_VEC_ERRSET, END_ERRSET))) {
-   		printf("Invalid mem object..\n");
+   		#ifdef DEBUG_SYR
+        printf("Invalid mem object..\n");
+        #endif
         return retCode;
     }
 
@@ -66,11 +68,15 @@ doSyr(
      * Need to be added.
      */
     if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, N, N, A, offa, lda, A_MAT_ERRSET))) {
+        #ifdef DEBUG_SYR
         printf("Invalid Size for A\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+        #ifdef DEBUG_SYR
         printf("Invalid Size for X\n");
+        #endif
         return retCode;
     }
 

--- a/src/library/blas/xsyr2.c
+++ b/src/library/blas/xsyr2.c
@@ -59,21 +59,29 @@ doSyr2(
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, X, Y, true, A_MAT_ERRSET, X_VEC_ERRSET, Y_VEC_ERRSET))) {
+        #ifdef DEBUG_SYR2
         printf("Invalid mem object..\n");
+        #endif
         return retCode;
     }
 
     if ((retCode = checkMatrixSizes(kargs->dtype, order, clblasNoTrans, N, N, A, offa, lda, A_MAT_ERRSET ))) {
+        #ifdef DEBUG_SYR2
         printf("Invalid Size for A\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, X, offx, incx, X_VEC_ERRSET))) {
+        #ifdef DEBUG_SYR2
         printf("Invalid Size for X\n");
+        #endif
         return retCode;
     }
 
 	if ((retCode = checkVectorSizes(kargs->dtype, N, Y, offy, incy, Y_VEC_ERRSET))) {
+        #ifdef DEBUG_SYR2
         printf("Invalid Size for Y\n");
+        #endif
         return retCode;
     }
 

--- a/src/library/blas/xtbmv.c
+++ b/src/library/blas/xtbmv.c
@@ -60,20 +60,28 @@ doTbmv(
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, x, y, true, A_MAT_ERRSET, X_VEC_ERRSET, Y_VEC_ERRSET))) {
-	printf("Invalid mem object..\n");
+	    #ifdef DEBUG_TBMV
+        printf("Invalid mem object..\n");
+        #endif
         return retCode;
     }
 
     if ((retCode = checkBandedMatrixSizes(kargs->dtype, order, trans, N, N, K, 0, A, offa, lda, A_MAT_ERRSET))) {
-		printf("Invalid Size for A\n");
+		#ifdef DEBUG_TBMV
+        printf("Invalid Size for A\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, x, offx, incx, X_VEC_ERRSET))) {
-		printf("Invalid Size for X\n");
+		#ifdef DEBUG_TBMV
+        printf("Invalid Size for X\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, y, 0, incx, Y_VEC_ERRSET))) {
-		printf("Invalid Size for scratch vector\n");
+		#ifdef DEBUG_TBMV
+        printf("Invalid Size for scratch vector\n");
+        #endif
         return retCode;
     }
 

--- a/src/library/blas/xtrmv.c
+++ b/src/library/blas/xtrmv.c
@@ -58,20 +58,28 @@ doTrmv(
     /* Validate arguments */
 
     if ((retCode = checkMemObjects(A, x, y, true, A_MAT_ERRSET, X_VEC_ERRSET, Y_VEC_ERRSET))) {
-	printf("Invalid mem object..\n");
+	    #ifdef DEBUG_TRMV
+        printf("Invalid mem object..\n");
+        #endif
         return retCode;
     }
 
     if ((retCode = checkMatrixSizes(kargs->dtype, order, trans, N, N, A, offa, lda, A_MAT_ERRSET))) {
-		printf("Invalid Size for A\n");
+		#ifdef DEBUG_TRMV
+        printf("Invalid Size for A\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, x, offx, incx, X_VEC_ERRSET))) {
-		printf("Invalid Size for X\n");
+		#ifdef DEBUG_TRMV
+        printf("Invalid Size for X\n");
+        #endif
         return retCode;
     }
     if ((retCode = checkVectorSizes(kargs->dtype, N, y, 0, incx, Y_VEC_ERRSET))) {
-		printf("Invalid Size for scratch vector\n");
+		#ifdef DEBUG_TRMV
+        printf("Invalid Size for scratch vector\n");
+        #endif
         return retCode;
     }
 


### PR DESCRIPTION
Three changes related to error-checking were made:
- The order of error-checking of the 3 matrices A, B, C for the SYMM routine was changed to match the order of other level-3 routines. Before: first check B, then C, then A. Now: first check A, then B, then C. This is consistent with other level-3 routines such as GEMM.
- Removal of debug `printf`-statements for the SYMM routine. Earlier, before an error-code was returned, a message was printed to screen. It is better to give control back to the caller of the function: the error-code contains the information that was printed. The `printf`'s are removed entirely to match the other level-3 routines.
- A good portion of the level-1 and level-2 routines contained similar `printf`-statements when an error-code was returned. They are now guarded with `#ifdef DEBUG_ROUTINENAME` sections.