### PR TITLE
Updated the computation of matrix memory requirements

### DIFF
--- a/src/library/blas/generic/common.c
+++ b/src/library/blas/generic/common.c
@@ -664,10 +664,10 @@ checkMatrixSizes(
         }
     }
 
-    //  It is possible to allocate a buffer, and set up lda & ldb such that it looks like it will access outside of the allocated buffer, but if
-    //  M & N are kept small enough, no out of bounds access will occur.  Compensate for the offset values and the unused tail memory caused by lda & ldb.
-    //  Ex: BuffSize=6 floats, M=1, N=2, lda=ldb=3, offA = 0, offB = 2 :  |A[0,0]|unused|B[0,0]|A[0,1]|unused|B[0,1]|
-    memUsed = (( offA + matrSize ) > unusedTail) ? offA + matrSize - unusedTail : offA + matrSize;
+    // Calculates the memory required. Note that 'matrSize' already takes into account the fact that
+    // there might be an unused tail, i.e. the elements between lda and M in the last column if
+    // column major is used or between lda and N in the last row if row major is used.
+    memUsed = offA + matrSize;
     if (( memUsed > memSize ) || (offA + matrSize < offA)) {
         switch( err )
         {
@@ -753,10 +753,10 @@ checkBandedMatrixSizes(
         }
     }
 
-    //  It is possible to allocate a buffer, and set up lda & ldb such that it looks like it will access outside of the allocated buffer, but if
-    //  M & N are kept small, no out of bounds access will occur.  Compensate for the offset values and the unused tail memory caused by lda & ldb.
-    //  Ex: BuffSize=6 floats, M=1, N=2, lda=ldb=3, offA = 0, offB = 2 :  |A[0,0]|unused|B[0,0]|A[0,1]|unused|B[0,1]|
-    memUsed = (( offA + matrSize ) > unusedTail) ? offA + matrSize - unusedTail : offA + matrSize;
+    // Calculates the memory required. Note that 'matrSize' already takes into account the fact that
+    // there might be an unused tail, i.e. the elements between lda and M in the last column if
+    // column major is used or between lda and N in the last row if row major is used.
+    memUsed = offA + matrSize;
     if (memUsed > memSize) {
         switch( err )
         {

--- a/src/library/blas/generic/common.c
+++ b/src/library/blas/generic/common.c
@@ -667,7 +667,7 @@ checkMatrixSizes(
     //  It is possible to allocate a buffer, and set up lda & ldb such that it looks like it will access outside of the allocated buffer, but if
     //  M & N are kept small enough, no out of bounds access will occur.  Compensate for the offset values and the unused tail memory caused by lda & ldb.
     //  Ex: BuffSize=6 floats, M=1, N=2, lda=ldb=3, offA = 0, offB = 2 :  |A[0,0]|unused|B[0,0]|A[0,1]|unused|B[0,1]|
-    memUsed = (( offA + matrSize ) > unusedTail) ? offA + matrSize - unusedTail: 0;
+    memUsed = (( offA + matrSize ) > unusedTail) ? offA + matrSize - unusedTail : offA + matrSize;
     if (( memUsed > memSize ) || (offA + matrSize < offA)) {
         switch( err )
         {
@@ -756,7 +756,7 @@ checkBandedMatrixSizes(
     //  It is possible to allocate a buffer, and set up lda & ldb such that it looks like it will access outside of the allocated buffer, but if
     //  M & N are kept small, no out of bounds access will occur.  Compensate for the offset values and the unused tail memory caused by lda & ldb.
     //  Ex: BuffSize=6 floats, M=1, N=2, lda=ldb=3, offA = 0, offB = 2 :  |A[0,0]|unused|B[0,0]|A[0,1]|unused|B[0,1]|
-    memUsed = (( offA + matrSize ) > unusedTail) ? offA + matrSize - unusedTail: 0;
+    memUsed = (( offA + matrSize ) > unusedTail) ? offA + matrSize - unusedTail : offA + matrSize;
     if (memUsed > memSize) {
         switch( err )
         {


### PR DESCRIPTION
When computing the requirement of an OpenCL buffer in the case of a matrix, there is a check for a corner case, described in `blas/generic/common.c` as:
> It is possible to allocate a buffer, and set up lda & ldb such that it looks like it will access outside of the allocated buffer, but if M & N are kept small enough, no out of bounds access will occur.  Compensate for the offset values and the unused tail memory caused by lda & ldb.

I don't doubt this corner-case, however, I am having trouble with the regular scenario, as the memory used is then set to zero:
```
if (( offA + matrSize ) > unusedTail) {
  memUsed = offA + matrSize - unusedTail;
} else {
  memUsed = 0; // Shouldn't this be "offA + matrSize"?
}
```

I applied a 'fix' in two cases, one for regular matrices and one for banded matrices. Note that this computation (as far as I see it) affects whether or not an error-code is returned.