### PR TITLE
fix the performance drop of SGEMM column major NT or row major TN when lda and ldb are big multiples of 1024 such as 4096, 5120, 6144, 7168, 8192

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -234,6 +234,7 @@ set (SRC_CL_TEMPLATES
     dtrsm_gpu192.cl
 	dgemm_gcn_SmallMatrices.cl
 	sgemm_gcn_SmallMatrices.cl
+	sgemm_gcn_bigMatrices.cl
 	sgemm_gcn.cl
 	zgemm_gcn.cl
 )
@@ -253,6 +254,9 @@ set(SRC_CL_TEMPLATES_GEN
 	sgemm_gcn_SmallMatrices.clHawaii_64.bin.cl
 	sgemm_gcn_SmallMatrices.clTahiti_64.bin.cl
     sgemm_gcn_SmallMatrices.clBonaire_64.bin.cl
+	sgemm_gcn_bigMatrices.clHawaii_64.bin.cl
+	sgemm_gcn_bigMatrices.clTahiti_64.bin.cl
+    sgemm_gcn_bigMatrices.clBonaire_64.bin.cl
 	sgemm_gcn.clHawaii_64.bin.cl
 	zgemm_gcn.clHawaii_64.bin.cl
     sgemm_gcn.clBonaire_64.bin.cl

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SRC_BLAS
 	blas/functor/gcn_dgemmSmallMatrices.cc
 	blas/functor/gcn_sgemmSmallMatrices.cc
 	blas/functor/hawaii_sgemmBranchKernel.cc
+	blas/functor/hawaii_sgemmBig1024Kernel.cc
 )
 
 set(SRC_BLAS_HEADERS
@@ -114,6 +115,7 @@ set(SRC_BLAS_HEADERS
 	blas/functor/include/gcn_dgemmSmallMatrices.h
 	blas/functor/include/gcn_sgemmSmallMatrices.h
 	blas/functor/include/hawaii_sgemmBranchKernel.h
+	blas/functor/include/hawaii_sgemmBig1024Kernel.h
 )
 
 set(SRC_BLAS_GENERIC

--- a/src/library/bingen.cmake
+++ b/src/library/bingen.cmake
@@ -15,6 +15,7 @@ ${CLTEMPLATE_PATH}/sgemm_hawaiiSplitKernel.cl
 ${CLTEMPLATE_PATH}/sgemm_gcn.cl
 ${CLTEMPLATE_PATH}/zgemm_gcn.cl
 ${CLTEMPLATE_PATH}/sgemm_gcn_SmallMatrices.cl
+${CLTEMPLATE_PATH}/sgemm_gcn_bigMatrices.cl
 ${CLTEMPLATE_PATH}/sgemm_hawaiiSplit64_32.cl
 ${CLTEMPLATE_PATH}/dtrsm_gpu192.cl
 )

--- a/src/library/blas/functor/hawaii.cc
+++ b/src/library/blas/functor/hawaii.cc
@@ -123,7 +123,9 @@ clblasSgemmFunctor * FunctorSelectorHawaii::select_sgemm_specific(clblasSgemmFun
 	  {
 		  if (args.lda != 6144)// 6144 is handled by a special case split
 		  {
-			  if (args.M % 128 == 0 && args.N % 128 == 0 && args.K % 64 == 0)
+			  // we are going to call 16 GEMMs with M=M/2, N=N/2, K=K/4
+			  // each GEMM requires M%128 == 0, N%128 == 0, K%16 == 0
+			  if (args.M % 256 == 0 && args.N % 256 == 0 && args.K % 64 == 0)
 			  {
 				  functor = clBlashawaiiSgemmBig1024KernelFunctor::provide(args, "Hawaii");
 				  if (functor)

--- a/src/library/blas/functor/hawaii.cc
+++ b/src/library/blas/functor/hawaii.cc
@@ -27,6 +27,7 @@
 #include "hawaii_sgemmSplit64_32.h"
 #include "gcn_zgemm.h"
 #include "gpu_dtrsm192.h"
+#include "hawaii_sgemmBig1024Kernel.h"
 
 FunctorSelectorHawaii FunctorSelectorHawaii::instance ;
 
@@ -115,6 +116,22 @@ clblasSgemmFunctor * FunctorSelectorHawaii::select_sgemm_specific(clblasSgemmFun
   //functor = clBlashawaiiSgemmSplit64_32Functor::provide(args, "Hawaii");
   //if (functor)
   //  return functor;
+
+  if ((args.lda % 1024 == 0) && (args.ldb % 1024 == 0) && (args.K > args.lda / 4))
+  {
+	  if ((args.lda == args.ldb) && (args.lda >= 4096) && (args.lda <= 8192)) // between 4096 and 8192 for now
+	  {
+		  if (args.lda != 6144)// 6144 is handled by a special case split
+		  {
+			  if (args.M % 128 == 0 && args.N % 128 == 0 && args.K % 64 == 0)
+			  {
+				  functor = clBlashawaiiSgemmBig1024KernelFunctor::provide(args, "Hawaii");
+				  if (functor)
+					  return functor;
+			  }
+		  }
+	  }
+  }
 
   if ((args.M >= 1184 && args.N >= 1184) && (args.M <= 3872 && args.N <= 3872) && (args.M % 64 != 0 && args.N % 64 != 0) && (args.M % 96 != 0 && args.N % 96 != 0) && (args.K % 16 == 0))
   {

--- a/src/library/blas/functor/hawaii_sgemmBig1024Kernel.cc
+++ b/src/library/blas/functor/hawaii_sgemmBig1024Kernel.cc
@@ -1,0 +1,388 @@
+#ifndef CLBLAS_HAWAII_DYNAMIC_KERNEL
+#include <stdio.h>
+#include <string.h>
+#include <clBLAS.h>
+
+#include <devinfo.h>
+#include "clblas-internal.h"
+#include "solution_seq.h"
+
+#include <functor.h>
+#include <binary_lookup.h>
+#include <iostream>
+
+#include <functor_xgemm.h>
+#include <tahiti.h>
+#include <hawaii.h>
+
+#include "BinaryBuild.h"
+#include "hawaii_sgemmBig1024Kernel.h"
+
+//only non-multiples of 32 is implemented right now, which is a small matrix.
+#if BUILD_KERNEL_FROM_STRING
+#include "sgemm_gcn_BigMatrices.clT"
+#else 
+#include "sgemm_gcn_BigMatrices.clHawaii_64.bin.clT"
+#include "sgemm_gcn_BigMatrices.clBonaire_64.bin.clT"
+#endif
+
+// Just because the full name is too long
+typedef clBlashawaiiSgemmBig1024KernelFunctor::Variant Variant;
+
+//define the string name of the soure/binary code
+#define SGEMM_SRC_NAME(TA,TB, DIVK, MULT)    sgemm_##TA##TB##_##DIVK##_SPLIT##MULT
+#define SGEMM_SRC_NAME_HAWAII(TA,TB, DIVK, MULT, BITS)   sgemm_##TA##TB##_##DIVK##_SPLIT##MULT##_##BITS##_bin_Hawaii
+#define SGEMM_SRC_NAME_BONAIRE(TA,TB, DIVK, MULT, BITS)   sgemm_##TA##TB##_##DIVK##_SPLIT##MULT##_##BITS##_bin_Bonaire
+#define SGEMM_SRC_NAME_BIN(TA,TB, DIVK, MULT, BITS, DEVICE)   SGEMM_SRC_NAME##_##DEVICE(TA,TB, DIVK, MULT, BITS)
+
+
+//variant name used to differentiate the different ones
+#define SGEMM_VARIANT_NAME(TA,TB, DIVK, MULT) "sgemm_" #TA #TB "_" #DIVK "_SPLIT" #MULT
+//SGEMM_VARIANT_NAME(TA, TB, DIVM , DIVN, DIVK, GREATER48M, GREATER48N, NBKERNEL),    
+
+#define SGEMM_KERNEL_NAME(TA,TB,DIVM,DIVN,DIVK,BS0,BS1,NV0,NV1,MULT) "sgemm_"  #TA #TB "_" #DIVM "_" #DIVN "_" #DIVK "_" #BS0 "x" #BS1 "_" #NV0 "x" #NV1 #MULT
+
+
+#define trans_N clblasNoTrans
+#define trans_T clblasTrans
+
+// Fill a variant descriptor using OpenCL source 
+#define SGEMM_VARIANT_OBJ(TA,TB,DIVK,BS0,BS1,NV0,NV1, BITS, MULT,  \
+  KERNEL_NAME_MAIN, \
+  KERNELS_SRC,  \
+  KERNEL_BUILD_OPTIONS,  \
+  KERNELS_BIN,  \
+  KERNEL_BIN_SIZE) { \
+  SGEMM_VARIANT_NAME(TA,TB, DIVK, MULT),                                          \
+{ KERNEL_NAME_MAIN } , \
+  KERNELS_SRC,  \
+  KERNEL_BUILD_OPTIONS, \
+  KERNELS_BIN, \
+  KERNEL_BIN_SIZE, \
+  trans_##TA, trans_##TB,                                       \
+  DIVK ,                                                        \
+{ BS0, BS1 } ,                                                \
+{ NV0, NV1 } ,                                                      \
+#MULT                                                               \
+} 
+
+typedef clblasFunctorCache<clBlashawaiiSgemmBig1024KernelFunctor, const Variant *> CacheBig1024;
+static CacheBig1024 cachebig1024;
+
+// Make it 1 to enable additional debug 'print' 
+#define VERB 0
+
+
+
+//static bool applicable( const Variant & var, clblasSgemmFunctor::Args & args, int RefMultiple ) 
+//{
+//#if 0
+//  // Transpose values are tested in select_variant
+//  if ( args.transA != var.transA ) return false ;
+//  if ( args.transB != var.transB ) return false ;
+//#endif
+//
+//  //if (args.N>=var.divN && args.N % var.divN != 0 )
+//  if ( args.N % var.divN != 0 ) 
+//    return false ; 
+//  if ( args.M % var.divM != 0 ) 
+//    return false ; 
+//  if(var.Greater[0]?args.M<RefMultiple:args.M>=RefMultiple)
+//    return false;
+//  if(var.Greater[1]?args.N<RefMultiple:args.N>=RefMultiple)
+//    return false;
+//  if ( args.beta==0 && var.mult.compare("__ALPHA")!=0)
+//    return false ;
+//  return true ;
+//}
+
+static void to_upper(char* input)
+{
+  while(*input)
+  {
+    *input=toupper(*input);
+    input++;
+  }
+}
+
+
+static const Variant * select_variant_Big1024Kernel(clblasSgemmFunctor::Args & args, const char* DevName, cl_uint _64BitsUse)
+{
+	if (_64BitsUse != 64)
+	{
+		std::cout << "we don't support clblas on 32 bits" << std::endl;
+		assert(1);
+		return NULL;
+	}
+
+
+	if (args.transA == clblasNoTrans)
+	{
+		if (args.transB == clblasNoTrans)
+		{
+
+			// ===== sgemm NN ======
+			// sgemm NN does not have big 1024 perf drop problem
+
+
+			return NULL;
+		}
+		if (args.transB == clblasTrans)
+		{
+
+
+			// ===== SGEMM NT ======
+			//sgemm_NT_128_128_16_16x16_8x8__ALPHABETA
+			const char* KName_NT = SGEMM_KERNEL_NAME(N, T, 128, 128, 16, 16, 16, 8, 8, __ALPHABETA);
+
+
+			const char* KBin_NT64;
+			size_t KBin_NTSize64 = 0;
+
+
+#if BUILD_KERNEL_FROM_STRING
+			//currently not supported
+			return NULL;
+#else
+			if (!strcmp(DevName, "Hawaii"))
+			{
+				//KBin_NT64             = SGEMM_SRC_NAME_BIN(N, T, 16, __ALPHABETA,  64, HAWAII) ;
+				KBin_NT64 = sgemm_NT_128_128_16_16x16_8x8__ALPHABETA_64_bin_Hawaii;
+				KBin_NTSize64 = sizeof(sgemm_NT_128_128_16_16x16_8x8__ALPHABETA_64_bin_Hawaii);
+
+			}
+
+#endif
+
+			// ===== SGEMM NT ======
+			static const Variant variant = SGEMM_VARIANT_OBJ(N, T, 16, 16, 16, 8, 8, 64, __ALPHABETA,
+				KName_NT,
+				NULL,
+				NULL,
+				KBin_NT64,
+				KBin_NTSize64);
+
+			return &variant;
+		}
+	}
+	else
+	{
+		if (args.transB == clblasNoTrans)
+		{
+
+				// ===== sgemm TN ======
+				//sgemm TN does not have big 1024 perf drop problem
+			    return NULL;
+		}
+		return NULL;
+	}
+
+		return NULL;
+}
+
+
+clBlashawaiiSgemmBig1024KernelFunctor::clBlashawaiiSgemmBig1024KernelFunctor(Args & args, const Variant * variant, cl_int & err)
+{
+
+  cl_device_id device;
+  cl_context context;
+  m_program=NULL;
+  m_variantBig1024 = variant;
+
+
+  cl_command_queue queue = args.queue;
+  err = getDeviceAndContext(queue, device, context);
+  if( err != CL_SUCCESS )
+  {
+    return;
+  }
+
+  if (VERB) printf(" ===> GET KERNEL %s\n", this->m_variantBig1024->variantName);
+
+  //Ben do I use the correct "kernel_name"?
+  BinaryLookup bl(context, device, "clBlashawaiiSgemmBig1024KernelFunctor");
+
+  bl.variantRaw(this->m_variantBig1024->variantName, strlen(this->m_variantBig1024->variantName) + 1);
+
+  if ( !bl.found() ) // may create empty file or may wait until file is ready  
+  {
+	if (this->m_variantBig1024->bin != NULL)
+    {
+      // build from a pre-compiled version of the kernel (SPIR or cl binaries)
+      //only 1 binary containing all the kernel
+	  err = bl.buildFromBinary(this->m_variantBig1024->bin, this->m_variantBig1024->bin_size, "-cl-std=2.0");
+    }
+    else
+    {
+      //// directly build from a char* 
+      if (VERB) printf(" ===> BUILD PROBLEM WE DON'T SUPPORT SOURCE BUILD FOR big 1024 SGEMM\n") ;
+      return;
+    } 
+
+    if ( err != CL_SUCCESS )
+    {  
+      if (VERB) printf(" ===> BUILD PROBLEM\n") ;
+
+      return;
+    }
+  }
+
+  this->m_program = bl.getProgram();
+}
+
+
+
+clBlashawaiiSgemmBig1024KernelFunctor *
+clBlashawaiiSgemmBig1024KernelFunctor::provide(clblasSgemmFunctor::Args & args, char* DevName)
+{
+
+  if ( args.order == clblasRowMajor ) 
+    return NULL ;   // The RowMajor case shall never occur. 
+
+  cl_device_id dev;
+  cl_context   ctxt;
+
+  cl_int err = getDeviceAndContext(args.queue, dev, ctxt);
+  if (err != CL_SUCCESS)
+  {
+    return NULL;
+  }
+  cl_uint bitness = getAddressBits(dev);
+
+  int major;
+  int minor;
+
+  getCLVersion(dev, major, minor);
+
+  //if (major<2)
+  //  return NULL;
+
+  // to_upper( DevName);
+  const Variant * variant = select_variant_Big1024Kernel(args, DevName, bitness);
+  if ( variant == NULL )  
+    return NULL ; 
+
+
+
+  CacheBig1024::Lookup lookup(cachebig1024, ctxt, dev, variant) ;
+
+
+  if ( lookup.ok() )
+  {
+	clBlashawaiiSgemmBig1024KernelFunctor * functor = lookup.get();
+    functor->retain(); // increment the reference counter to avoid deletion while it is still beeing used
+    return functor;
+  }
+
+  clBlashawaiiSgemmBig1024KernelFunctor * functor = new clBlashawaiiSgemmBig1024KernelFunctor(args, variant, err);
+  if (err != CL_SUCCESS)
+  {
+    return NULL;
+  }
+
+  lookup.set(functor) ;
+
+  return functor;
+
+}
+
+
+cl_int clBlashawaiiSgemmBig1024KernelFunctor::KernelsLaunch(cl_command_queue queue, cl_kernel Kernel[1], Args &args)
+{
+  //((Mvalue - 1) / 128 + 1) * 16
+  size_t GlobalX = ((args.M-1) / 128 + 1)*16 ;
+  
+  //
+
+  size_t GlobalY = ((args.N - 1) / 128 + 1) * 16;
+
+
+  std::size_t gs[2] = {GlobalX, GlobalY};
+  cl_int error = 0;
+
+
+  //if (VERB) printf(" ===> EXECUTE KERNEL 0 \n") ;
+  error = clEnqueueNDRangeKernel(queue, Kernel[0], 2, NULL, gs, m_variantBig1024->ls, args.numEventsInWaitList, args.eventWaitList,args.events);
+  return error;
+
+
+  return clblasNotImplemented;
+}
+
+
+
+clblasStatus clBlashawaiiSgemmBig1024KernelFunctor::execute(Args &args)
+{
+  cl_int err;
+  cl_command_queue queue = args.queue;
+
+  if (VERB) printf(" ===> EXECUTE KERNEL %s, alpha =%f ,beta = %f\n", this->m_variantBig1024->kernel_name, args.alpha, args.beta);
+
+  cl_kernel kernel[1]; 
+  int NBKernel = 0;
+
+
+  if (this->m_variantBig1024->kernel_name[0])
+  {
+	kernel[0] = clCreateKernel(this->m_program, this->m_variantBig1024->kernel_name[0], &err);
+    if (err != CL_SUCCESS)
+        return clblasStatus(err) ; 
+    NBKernel++;
+  }
+
+
+  if (NBKernel != 1) return clblasStatus(clblasBuildProgramFailure) ; 
+
+  if (VERB)
+  {
+    for (int i=0; i<NBKernel; i++)
+		printf(" ===> FOUND %s\n", this->m_variantBig1024->kernel_name[i]);
+  }
+
+  int M   = args.M, N = args.N, K = args.K;
+  int lda = args.lda, ldb = args.ldb, ldc = args.ldc;
+
+  int offsetA = args.offA;
+  int offsetB = args.offB;
+  int offsetC = args.offC;
+
+  int arg[4]={0, 0, 0, 0} ; 
+
+  //// All sgemm kernels shall have the same arguments: (A,B,C,M,N,K,alpha,beta,lda,ldb,ldc,offa,offb,offc) 
+
+  for (int i=0; i<NBKernel; i++)
+  {
+    setKernelArg<cl_mem>(kernel[i], arg[i]++, args.A);
+    setKernelArg<cl_mem>(kernel[i], arg[i]++, args.B);
+    setKernelArg<cl_mem>(kernel[i], arg[i]++, args.C);
+
+    setKernelArg<int>(kernel[i], arg[i]++, M);
+    setKernelArg<int>(kernel[i], arg[i]++, N);
+    setKernelArg<int>(kernel[i], arg[i]++, K);
+
+    setKernelArg<cl_float>(kernel[i], arg[i]++, args.alpha);
+    setKernelArg<cl_float>(kernel[i], arg[i]++, args.beta);
+
+    setKernelArg<int>(kernel[i], arg[i]++, lda);
+    setKernelArg<int>(kernel[i], arg[i]++, ldb);
+    setKernelArg<int>(kernel[i], arg[i]++, ldc);
+
+    setKernelArg<int>(kernel[i], arg[i]++, offsetA);
+    setKernelArg<int>(kernel[i], arg[i]++, offsetB);
+    setKernelArg<int>(kernel[i], arg[i]++, offsetC);
+  }
+
+  err = KernelsLaunch(queue, kernel, args);
+
+
+
+  for (int i = 0; i<NBKernel; i++)
+    clReleaseKernel(kernel[i]) ;
+
+  if (VERB) printf(" ===> ERR=%d \n",(int)err) ;
+
+  // err= clFinish(queue);
+  return clblasStatus(err) ;
+
+}
+#endif

--- a/src/library/blas/functor/include/hawaii_sgemmBig1024Kernel.h
+++ b/src/library/blas/functor/include/hawaii_sgemmBig1024Kernel.h
@@ -1,0 +1,48 @@
+/*
+Handles lda=ldb=4096, 5120, 7168, 8192
+lda=ldb=6144 should be handled by a special case in hawaii_sgemmSplitKernel
+*/
+#ifndef HAWAII_SGEMMBIG1024KERNEL
+#define HAWAII_SGEMMBIG1024KERNEL
+
+#include "gcn_sgemm.h"
+
+
+class clBlashawaiiSgemmBig1024KernelFunctor  : public clblasSgemmFunctorGCN 
+{
+public:
+  struct Variant 
+  {    
+    const char *    variantName;
+    const char *    kernel_name[1] ;  //just one kernel here
+    const char *    source ;   // the kernel source (shall be unique)
+    const char *    build_options;
+    const char *    bin ; 
+    size_t          bin_size ; 
+    clblasTranspose transA ;   //
+    clblasTranspose transB ;   //
+    unsigned        divK ;     // Required divisor of N  (use 1 when N can be of any value) 
+    size_t          ls[2]  ;   // Local size (the work-group size)
+    size_t          bwi[2] ;   // Block size work-item:  Number of elements calculated by each work items 
+                               // So basically each kernel is computing a block of
+                               //   (ls[0]*bwi[0]) x (ls[1]*bwi[1])  
+                               // elements of C. 
+    std::string mult;
+    
+  } ;
+
+
+  private:  // Constructor & Destructor
+
+  clBlashawaiiSgemmBig1024KernelFunctor(Args & args, const Variant * variant, cl_int & err);
+  cl_int KernelsLaunch(cl_command_queue queue, cl_kernel Kernel[1], Args &args);
+  const Variant * m_variantBig1024 ; // Pointer to a 'const static' object describing the kernel variant. 
+  
+public:
+
+  static clBlashawaiiSgemmBig1024KernelFunctor * provide(clblasSgemmFunctor::Args & args, char* DevName);
+  virtual clblasStatus execute(Args &args) ;
+
+};
+
+#endif

--- a/src/library/blas/gens/clTemplates/sgemm_gcn_bigMatrices.cl
+++ b/src/library/blas/gens/clTemplates/sgemm_gcn_bigMatrices.cl
@@ -1,0 +1,264 @@
+static const char * sgemm_NT_128_128_16_16x16_8x8__ALPHABETA = "
+#define  M8x8 \
+            rA[0][0] = lA[offA + 0];				  \
+            rA[0][1] = lA[offA + 16];				  \
+            rA[0][2] = lA[offA + 32];				  \
+            rA[0][3] = lA[offA + 48];				  \
+            rA[0][4] = lA[offA + 64];				  \
+            rA[0][5] = lA[offA + 80];				  \
+            rA[0][6] = lA[offA + 96];				  \
+            rA[0][7] = lA[offA + 112];				  \
+            rB[0][0] = lB[offB + 0];				  \
+            rB[0][1] = lB[offB + 16];				  \
+            rB[0][2] = lB[offB + 32];				  \
+            rB[0][3] = lB[offB + 48];				  \
+            rB[0][4] = lB[offB + 64];				  \
+            rB[0][5] = lB[offB + 80];				  \
+            rB[0][6] = lB[offB + 96];				  \
+            rB[0][7] = lB[offB + 112];				  \
+            offA += 129;							  \
+            offB += 129;							  \
+            rC[0][0]=mad(rA[0][0],rB[0][0],rC[0][0]); \
+            rC[1][0]=mad(rA[0][1],rB[0][0],rC[1][0]); \
+            rC[2][0]=mad(rA[0][2],rB[0][0],rC[2][0]); \
+            rC[3][0]=mad(rA[0][3],rB[0][0],rC[3][0]); \
+            rC[4][0]=mad(rA[0][4],rB[0][0],rC[4][0]); \
+            rC[5][0]=mad(rA[0][5],rB[0][0],rC[5][0]); \
+            rC[6][0]=mad(rA[0][6],rB[0][0],rC[6][0]); \
+            rC[7][0]=mad(rA[0][7],rB[0][0],rC[7][0]); \		
+            rC[0][1]=mad(rA[0][0],rB[0][1],rC[0][1]); \
+            rC[1][1]=mad(rA[0][1],rB[0][1],rC[1][1]); \
+            rC[2][1]=mad(rA[0][2],rB[0][1],rC[2][1]); \
+            rC[3][1]=mad(rA[0][3],rB[0][1],rC[3][1]); \
+            rC[4][1]=mad(rA[0][4],rB[0][1],rC[4][1]); \
+            rC[5][1]=mad(rA[0][5],rB[0][1],rC[5][1]); \
+            rC[6][1]=mad(rA[0][6],rB[0][1],rC[6][1]); \	
+            rC[7][1]=mad(rA[0][7],rB[0][1],rC[7][1]); \				
+            rC[0][2]=mad(rA[0][0],rB[0][2],rC[0][2]); \
+            rC[1][2]=mad(rA[0][1],rB[0][2],rC[1][2]); \
+            rC[2][2]=mad(rA[0][2],rB[0][2],rC[2][2]); \
+            rC[3][2]=mad(rA[0][3],rB[0][2],rC[3][2]); \
+            rC[4][2]=mad(rA[0][4],rB[0][2],rC[4][2]); \
+            rC[5][2]=mad(rA[0][5],rB[0][2],rC[5][2]); \
+            rC[6][2]=mad(rA[0][6],rB[0][2],rC[6][2]); \
+            rC[7][2]=mad(rA[0][7],rB[0][2],rC[7][2]); \			
+            rC[0][3]=mad(rA[0][0],rB[0][3],rC[0][3]); \
+            rC[1][3]=mad(rA[0][1],rB[0][3],rC[1][3]); \
+            rC[2][3]=mad(rA[0][2],rB[0][3],rC[2][3]); \
+            rC[3][3]=mad(rA[0][3],rB[0][3],rC[3][3]); \
+            rC[4][3]=mad(rA[0][4],rB[0][3],rC[4][3]); \
+            rC[5][3]=mad(rA[0][5],rB[0][3],rC[5][3]); \
+            rC[6][3]=mad(rA[0][6],rB[0][3],rC[6][3]); \
+            rC[7][3]=mad(rA[0][7],rB[0][3],rC[7][3]); \			
+            rC[0][4]=mad(rA[0][0],rB[0][4],rC[0][4]); \
+            rC[1][4]=mad(rA[0][1],rB[0][4],rC[1][4]); \
+            rC[2][4]=mad(rA[0][2],rB[0][4],rC[2][4]); \
+            rC[3][4]=mad(rA[0][3],rB[0][4],rC[3][4]); \
+            rC[4][4]=mad(rA[0][4],rB[0][4],rC[4][4]); \
+            rC[5][4]=mad(rA[0][5],rB[0][4],rC[5][4]); \
+            rC[6][4]=mad(rA[0][6],rB[0][4],rC[6][4]); \
+            rC[7][4]=mad(rA[0][7],rB[0][4],rC[7][4]); \			
+            rC[0][5]=mad(rA[0][0],rB[0][5],rC[0][5]); \
+            rC[1][5]=mad(rA[0][1],rB[0][5],rC[1][5]); \
+            rC[2][5]=mad(rA[0][2],rB[0][5],rC[2][5]); \
+            rC[3][5]=mad(rA[0][3],rB[0][5],rC[3][5]); \
+            rC[4][5]=mad(rA[0][4],rB[0][5],rC[4][5]); \
+            rC[5][5]=mad(rA[0][5],rB[0][5],rC[5][5]); \	
+            rC[6][5]=mad(rA[0][6],rB[0][5],rC[6][5]); \	
+            rC[7][5]=mad(rA[0][7],rB[0][5],rC[7][5]); \				
+            rC[0][6]=mad(rA[0][0],rB[0][6],rC[0][6]); \
+            rC[1][6]=mad(rA[0][1],rB[0][6],rC[1][6]); \
+            rC[2][6]=mad(rA[0][2],rB[0][6],rC[2][6]); \
+            rC[3][6]=mad(rA[0][3],rB[0][6],rC[3][6]); \
+            rC[4][6]=mad(rA[0][4],rB[0][6],rC[4][6]); \
+            rC[5][6]=mad(rA[0][5],rB[0][6],rC[5][6]); \	
+            rC[6][6]=mad(rA[0][6],rB[0][6],rC[6][6]); \	
+            rC[7][6]=mad(rA[0][7],rB[0][6],rC[7][6]); \				
+            rC[0][7]=mad(rA[0][0],rB[0][7],rC[0][7]); \
+            rC[1][7]=mad(rA[0][1],rB[0][7],rC[1][7]); \
+            rC[2][7]=mad(rA[0][2],rB[0][7],rC[2][7]); \
+            rC[3][7]=mad(rA[0][3],rB[0][7],rC[3][7]); \
+            rC[4][7]=mad(rA[0][4],rB[0][7],rC[4][7]); \
+            rC[5][7]=mad(rA[0][5],rB[0][7],rC[5][7]); \	
+            rC[6][7]=mad(rA[0][6],rB[0][7],rC[6][7]); \	
+            rC[7][7]=mad(rA[0][7],rB[0][7],rC[7][7]); \				
+            mem_fence(CLK_LOCAL_MEM_FENCE);
+			
+__attribute__((reqd_work_group_size(16,16,1)))
+__kernel void sgemm_NT_128_128_16_16x16_8x8__ALPHABETA( __global float const * restrict A,
+  __global float const * restrict B,
+  __global float * C,
+  uint const M,
+  uint const N,
+  uint const K,
+  float const alpha,
+  float const beta,
+  uint lda,
+  uint ldb,
+  uint ldc,
+  uint offsetA,
+  uint offsetB,
+  uint offsetC)
+ {
+     float rC[8][8]  = {(float)0};
+    float rA[1][8];
+    float rB[1][8];
+    
+//    GPtr uA, uB;
+//    uA.floatv = (__global float *)A;
+//    uB.floatv = (__global float *)B;
+    
+    A += offsetA;
+    B += offsetB;
+    C+=offsetC;
+    
+    __local float lA[2064];
+    __local float lB[2064];
+    
+    uint gidx = get_group_id(0);
+    uint gidy = get_group_id(1);
+    uint idx = get_local_id(0);
+    uint idy = get_local_id(1);
+    
+    uint idt = 16*idy + idx;
+    uint idxT = idt % 16;
+    uint idyT = idt / 16;
+    
+    A +=  gidx*128+ idxT + idyT*lda;
+    B +=  gidy*128+ idxT + idyT*ldb;
+    
+   
+    uint block_k = K >> 4;
+    do 
+	{
+   // for(unsigned int block_k=0 ; block_k< K ; block_k+=16)
+	//{
+        __local float* plA = lA + idyT*129+idxT;
+        __local float* plB = lB + idyT*129+idxT;
+        barrier(CLK_LOCAL_MEM_FENCE);
+        plB[0] = B[0+0*ldb];
+        plB[16] = B[16+0*ldb];
+        plB[32] = B[32+0*ldb];
+        plB[48] = B[48+0*ldb];
+        plB[64] = B[64+0*ldb];
+        plB[80] = B[80+0*ldb];
+        plB[96] = B[96+0*ldb];
+        plB[112] = B[112+0*ldb];
+	   
+	    plA[0] = A[0+0*lda];
+        plA[16] = A[16+0*lda];
+        plA[32] = A[32+0*lda];
+        plA[48] = A[48+0*lda];
+        plA[64] = A[64+0*lda];
+        plA[80] = A[80+0*lda];
+        plA[96] = A[96+0*lda];
+        plA[112] = A[112+0*lda];
+        
+        barrier(CLK_LOCAL_MEM_FENCE);
+        uint offA = idx;
+        uint offB = idy;
+
+//        #pragma unroll 1
+//        for(unsigned int k = 0 ; k < 16; k+=1){
+//        }
+
+        M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+		M8x8
+
+        A += lda<<4;
+        B += ldb<<4;
+    //}
+	} while (--block_k > 0);
+
+    C+= gidx*128+idx;
+    C+= gidy*128*ldc;
+    C+= idy*ldc;
+    
+	C[0*ldc] = alpha*rC[0][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[0][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[0][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[0][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[0][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[0][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[0][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[0][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[1][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[1][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[1][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[1][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[1][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[1][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[1][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[1][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[2][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[2][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[2][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[2][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[2][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[2][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[2][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[2][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[3][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[3][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[3][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[3][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[3][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[3][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[3][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[3][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[4][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[4][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[4][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[4][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[4][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[4][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[4][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[4][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[5][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[5][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[5][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[5][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[5][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[5][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[5][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[5][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[6][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[6][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[6][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[6][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[6][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[6][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[6][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[6][7] + beta*C[112*ldc];
+    C+=16;
+    C[0*ldc] = alpha*rC[7][0] + beta*C[0*ldc];
+    C[16*ldc] = alpha*rC[7][1] + beta*C[16*ldc];
+    C[32*ldc] = alpha*rC[7][2] + beta*C[32*ldc];
+    C[48*ldc] = alpha*rC[7][3] + beta*C[48*ldc];
+    C[64*ldc] = alpha*rC[7][4] + beta*C[64*ldc];
+    C[80*ldc] = alpha*rC[7][5] + beta*C[80*ldc];
+    C[96*ldc] = alpha*rC[7][6] + beta*C[96*ldc];
+    C[112*ldc] = alpha*rC[7][7] + beta*C[112*ldc];
+ }
+			
+";

--- a/src/library/blas/xgemm.cc
+++ b/src/library/blas/xgemm.cc
@@ -165,6 +165,7 @@ clblasDgemm( clblasOrder order,
              const cl_event *eventWaitList,
              cl_event *events)
 {
+//printf("dgemm M=%i,N=%i,K=%i,lda=%i,ldb=%i,ldc=%i\n", M, N, K, lda, ldb, ldc);
    CHECK_QUEUES(numCommandQueues, commandQueues);
    CHECK_EVENTS(numEventsInWaitList, eventWaitList);
    CHECK_MATRIX_A(TYPE_DOUBLE, order, transA, A, M, K, offA, lda);


### PR DESCRIPTION
This PR is an attempt to fix the performance drop of SGEMM column major NT or row major TN when lda and ldb are big multiples of 1024 such as 4096, 5120, 6144, 7168, 8192 and so forth.

The performance drop at those sizes are likely caused by cache trashing that multiple CUs are trying to read from the same global memory channel. The easiest way to fix this problem is to pad the input data by lda and ldb (such as lda = 4097, ldb = 4097). However, an OpenCL level library does not have the control over how users allocate the host memory. In this regard, it is worthwhile to try to fix this problem from within the library.

At size 4096 and 5120 we choose to use kernels with macro tile size of 128 instead of 96. Doing this effectively reduces the number of work groups and thus reduces the chance of different CUs reading from the same channel at the same time. 

At size 6144 we choose to still use kernels with macro tile size of 96 (uses fewer register as opposed to 128 approach). The change made here is instead of calling one GEMM kernel where M=N=K=6144 we make 4 identical GEMM calls where M=N=6144 and K=1536. 

This is based on some experimental results on kernel with macro tile size of 96 shown below.
![sgemm4096_sweepk](https://cloud.githubusercontent.com/assets/4991391/9310918/8b553b9e-44d8-11e5-8db7-be86ba5dcb19.png)

It can be seen when K>3584 in our experiment the performance starts to drop. Note that the 4-kernel approach requires updates on offsetA, offsetB and beta.

It seems for even bigger sizes the 4-kernel approach is no longer sufficient. For size 7168 and 8192 we attempt to split C matrix as well. For example. instead of calling one GEMM kernel where M=N=K=8192 we make 16 identical GEMM calls where M=N=4096 and K=2048. Note that updates on offsetA, offsetB, offsetC and beta are required.

Below shows the performance graph from this PR against current clBLAS performance.

![clblas_sgemmnt_channel](https://cloud.githubusercontent.com/assets/4991391/9310746/3f5d2bf8-44d7-11e5-8d57-4a6a95a9b03e.png)

Note that for even bigger matrix sizes (> 8192) it is likely that we need to further split the matrices. Analysis on non-square cases (lda!=ldb, lda%1024 == 0, ldb%1024==0) might also be interesting.