### PR TITLE
add missing includes on stdlib

### DIFF
--- a/src/library/blas/functor/functor.cc
+++ b/src/library/blas/functor/functor.cc
@@ -15,6 +15,7 @@
  * ************************************************************************/
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <fstream>
 #include <iostream>
 #include <ios>

--- a/src/library/blas/generic/binary_lookup.cc
+++ b/src/library/blas/generic/binary_lookup.cc
@@ -28,7 +28,7 @@
 #include <sys/stat.h>
 
 #include <devinfo.h>
-
+#include <stdlib.h>
 
 
 


### PR DESCRIPTION
Similar to the bug reported in `clFFT`. Some missing inclusion of `stdlib.h` prevent compilation on most architectures but `amd64`.