### PR TITLE
Fix redefinition warnings when using with clFFT

### DIFF
--- a/src/library/blas/generic/binary_lookup.cc
+++ b/src/library/blas/generic/binary_lookup.cc
@@ -54,7 +54,7 @@ extern "C"
 
 #include <string.h>
 
-char * sep()
+static char * sep()
 {
 #ifdef __WIN32
     return (char*)"\\";
@@ -195,7 +195,7 @@ enum BinaryRepresentation
     UNKNOWN
 };
 
-enum BinaryRepresentation getStorageMode(char * data)
+static enum BinaryRepresentation getStorageMode(char * data)
 {
     if (data[0] == 'C' && 
         data[1] == 'L' && 


### PR DESCRIPTION
seq and getStorageMode are defined in both clBLAS and clFFT. This causes redefinition warnings when using both in the same project.
Opened PR in https://github.com/clMathLibraries/clFFT/pull/103