### PR TITLE
Fix catch-22 in build order, following pull-163, where init.c compile…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # vim temp files
 .*.swp
+
+src/build/
+

--- a/src/library/blas/AutoGemm/AutoGemmTeardown.h
+++ b/src/library/blas/AutoGemm/AutoGemmTeardown.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#ifdef __cplusplus
+#extern "C" {
+#endif
+  void initAutoGemmClKernels(void);
+#ifdef __cplusplus
+}
+#endif
+

--- a/src/library/blas/init.c
+++ b/src/library/blas/init.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #ifdef BUILDING_CLBLAS
-#include "AutoGemmIncludes/AutoGemmClKernels.h"
+#include "AutoGemmTeardown.h"
 #endif
 
 clblasStatus


### PR DESCRIPTION
… fails because AutoGemmClKernels.h hasnt been built yet

Fix bug in https://github.com/clMathLibraries/clBLAS/pull/163 , where it wont build the first time, since init.c needs AutoGemmClKernels.h, which hasnt been generated yet.