### PR TITLE
add missing include on stdlib.h

### DIFF
--- a/src/library/blas/xtrsm.cc
+++ b/src/library/blas/xtrsm.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  * ************************************************************************/
 
-
+#include <stdlib.h>
 #include <string.h>
 #include <clBLAS.h>
 


### PR DESCRIPTION
The stdlib include is required for calloc / free. Fixes an FTBFS error on Debian.