### PR TITLE
fix hard-coding of opencl version to 2.0; fix 1d initialization of 2d…

### DIFF
--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -851,6 +851,7 @@ set(CLBLAS_ALL_SOURCES
 	#${USERGEMM_SRC}
 	#${USERGEMM_HEADERS}
 )
+add_definitions(-DOPENCL_VERSION="${OPENCL_VERSION}")
 add_library(clBLAS ${CLBLAS_ALL_SOURCES})
 add_dependencies(clBLAS GENERATE_CLT)
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/UserGemmKernelSourceIncludes.h
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/UserGemmKernelSourceIncludes.h
@@ -9,8 +9,8 @@
 
 //**** compiler flags
 //**** online compilation flags
-const char * const User_srcBuildOptions = "-cl-std=CL2.0";
-const char * const User_binBuildOptions = "-cl-std=CL2.0";
+const char * const User_srcBuildOptions = "-cl-std=CL" OPENCL_VERSION;
+const char * const User_binBuildOptions = "-cl-std=CL" OPENCL_VERSION;
 
 
 extern const unsigned int sgemm_Col_NT_B1_MX032_NX064_KX16_ROW_workGroupNumRows;

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B0_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B0_MX048_NX048_KX08_src.cpp
@@ -96,7 +96,7 @@ __kernel void dgemm_Col_NN_B0_MX048_NX048_KX08 (
     C += offsetC;
 
 
-    double rC[6][6] = {(double)0};
+    double rC[6][6] = { {(double)0} };
     double rA[6];
     double rB[6];
   __local double lA[392];

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B1_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B1_MX048_NX048_KX08_src.cpp
@@ -94,7 +94,7 @@ __kernel void dgemm_Col_NN_B1_MX048_NX048_KX08 (
     C += offsetC;
 
 
-    double rC[6][6] = {(double)0};
+    double rC[6][6] = { {(double)0} };
     double rA[6];
     double rB[6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B0_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B0_MX048_NX048_KX08_src.cpp
@@ -108,7 +108,7 @@ const char * const dgemm_Col_NT_B0_MX048_NX048_KX08_src = STRINGIFY(
 \n    C    += offsetC;
 \n
 \n
-\n    double rC[6][6] = {(double)0};
+\n    double rC[6][6] = { {(double)0} };
 \n    double rA[6];
 \n    double rB[6];
 \n

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B1_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B1_MX048_NX048_KX08_src.cpp
@@ -107,7 +107,7 @@ const char * const dgemm_Col_NT_B1_MX048_NX048_KX08_src = STRINGIFY(
 \n    C    += offsetC;
 \n
 \n
-\n    double rC[6][6] = {(double)0};
+\n    double rC[6][6] = { {(double)0} };
 \n    double rA[6];
 \n    double rB[6];
 \n

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B0_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B0_MX048_NX048_KX08_src.cpp
@@ -36,7 +36,7 @@ __kernel void dgemm_Col_TN_B0_MX048_NX048_KX08_src (
   uint const offsetB,
   uint const offsetC )
 {
-    double rC[6][6]  = {(double)0};
+    double rC[6][6]  = { {(double)0} };
     double rA[1][6];
     double rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B1_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B1_MX048_NX048_KX08_src.cpp
@@ -36,7 +36,7 @@ __kernel void dgemm_Col_TN_B1_MX048_NX048_KX08_src (
   uint const offsetB,
   uint const offsetC )
 {
-    double rC[6][6]  = {(double)0};
+    double rC[6][6]  = { {(double)0} };
     double rA[1][6];
     double rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B0_MX032_NX032_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B0_MX032_NX032_KX16_src.cpp
@@ -49,7 +49,7 @@ __kernel void sgemm_Col_NN_B0_MX032_NX032_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B0_MX064_NX064_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B0_MX064_NX064_KX16_src.cpp
@@ -65,7 +65,7 @@ __kernel void sgemm_Col_NN_B0_MX064_NX064_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[4][4]  = {(float)0};
+    float rC[4][4]  = { {(float)0} };
     float rA[1][4];
     float rB[1][4];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B0_MX096_NX096_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B0_MX096_NX096_KX16_src.cpp
@@ -89,7 +89,7 @@ __kernel void sgemm_Col_NN_B0_MX096_NX096_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[6][6]  = {(float)0};
+    float rC[6][6]  = { {(float)0} };
     float rA[1][6];
     float rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX032_NX032_KX16_BRANCH_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX032_NX032_KX16_BRANCH_src.cpp
@@ -54,7 +54,7 @@ __kernel void sgemm_Col_NN_B1_MX032_NX032_KX16_BRANCH (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
     

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX032_NX032_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX032_NX032_KX16_src.cpp
@@ -49,7 +49,7 @@ __kernel void sgemm_Col_NN_B1_MX032_NX032_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX064_NX064_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX064_NX064_KX16_src.cpp
@@ -65,7 +65,7 @@ __kernel void sgemm_Col_NN_B1_MX064_NX064_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[4][4]  = {(float)0};
+    float rC[4][4]  = { {(float)0} };
     float rA[1][4];
     float rB[1][4];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX096_NX096_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NN_B1_MX096_NX096_KX16_src.cpp
@@ -89,7 +89,7 @@ __kernel void sgemm_Col_NN_B1_MX096_NX096_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[6][6]  = {(float)0};
+    float rC[6][6]  = { {(float)0} };
     float rA[1][6];
     float rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B0_MX032_NX032_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B0_MX032_NX032_KX16_src.cpp
@@ -49,7 +49,7 @@ __kernel void sgemm_Col_NT_B0_MX032_NX032_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B0_MX064_NX064_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B0_MX064_NX064_KX16_src.cpp
@@ -66,7 +66,7 @@ __kernel void sgemm_Col_NT_B0_MX064_NX064_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[4][4]  = {(float)0};
+    float rC[4][4]  = { {(float)0} };
     float rA[1][4];
     float rB[1][4];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B0_MX096_NX096_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B0_MX096_NX096_KX16_src.cpp
@@ -90,7 +90,7 @@ __kernel void sgemm_Col_NT_B0_MX096_NX096_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[6][6]  = {(float)0};
+    float rC[6][6]  = { {(float)0} };
     float rA[1][6];
     float rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX032_NX032_KX16_BRANCH_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX032_NX032_KX16_BRANCH_src.cpp
@@ -54,7 +54,7 @@ __kernel void sgemm_Col_NT_B1_MX032_NX032_KX16_BRANCH (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
     

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX032_NX032_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX032_NX032_KX16_src.cpp
@@ -49,7 +49,7 @@ __kernel void sgemm_Col_NT_B1_MX032_NX032_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX064_NX064_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX064_NX064_KX16_src.cpp
@@ -65,7 +65,7 @@ __kernel void sgemm_Col_NT_B1_MX064_NX064_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[4][4]  = {(float)0};
+    float rC[4][4]  = { {(float)0} };
     float rA[1][4];
     float rB[1][4];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX096_NX096_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_NT_B1_MX096_NX096_KX16_src.cpp
@@ -91,7 +91,7 @@ __kernel void sgemm_Col_NT_B1_MX096_NX096_KX16 (
   uint offsetB,
   uint offsetC)
 {
-    float rC[6][6]  = {(float)0};
+    float rC[6][6]  = { {(float)0} };
     float rA[1][6];
     float rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B0_MX032_NX032_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B0_MX032_NX032_KX16_src.cpp
@@ -49,7 +49,7 @@ __kernel void sgemm_Col_TN_B0_MX032_NX032_KX16_src (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B0_MX064_NX064_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B0_MX064_NX064_KX16_src.cpp
@@ -65,7 +65,7 @@ __kernel void sgemm_Col_TN_B0_MX064_NX064_KX16 (
    uint offsetB,
    uint offsetC)
 {
-  float rC[4][4]  = {(float)0};
+  float rC[4][4]  = { {(float)0} };
   float rA[1][4];
   float rB[1][4];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B0_MX096_NX096_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B0_MX096_NX096_KX16_src.cpp
@@ -89,7 +89,7 @@ __kernel void sgemm_Col_TN_B0_MX096_NX096_KX16 (
   uint offsetB,
   uint offsetC)
 {
-  float rC[6][6]  = {(float)0};
+  float rC[6][6]  = { {(float)0} };
   float rA[1][6];
   float rB[1][6];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX032_NX032_KX16_BRANCH_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX032_NX032_KX16_BRANCH_src.cpp
@@ -54,7 +54,7 @@ __kernel void sgemm_Col_TN_B1_MX032_NX032_KX16_BRANCH_src (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
     

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX032_NX032_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX032_NX032_KX16_src.cpp
@@ -49,7 +49,7 @@ __kernel void sgemm_Col_TN_B1_MX032_NX032_KX16_src (
   uint offsetB,
   uint offsetC)
 {
-    float rC[2][2]  = {(float)0};
+    float rC[2][2]  = { {(float)0} };
     float rA[1][2];
     float rB[1][2];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX064_NX064_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX064_NX064_KX16_src.cpp
@@ -65,7 +65,7 @@ __kernel void sgemm_Col_TN_B1_MX064_NX064_KX16 (
   uint offsetB,
   uint offsetC)
 {
-  float rC[4][4]  = {(float)0};
+  float rC[4][4]  = { {(float)0} };
   float rA[1][4];
   float rB[1][4];
 

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX096_NX096_KX16_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/sgemm_Col_TN_B1_MX096_NX096_KX16_src.cpp
@@ -89,7 +89,7 @@ __kernel void sgemm_Col_TN_B1_MX096_NX096_KX16 (
   uint offsetB,
   uint offsetC)
 {
-  float rC[6][6]  = {(float)0};
+  float rC[6][6]  = { {(float)0} };
   float rA[1][6];
   float rB[1][6];
 


### PR DESCRIPTION
… arrays.

Fixes the two bugs identified in https://github.com/clMathLibraries/clBLAS/issues/172

This means that the test code runs to completion for hte first iteration, before failing with an error -38 now. Error -38 will be fixed in a pull request for 2111bb03936 , once I have reproduced the issue, and demonstrated that 2111bb03936 fixes it.
