### PR TITLE
Protect pragma in preprocessor macro by using _Pragma. clang 3.7 will…

### DIFF
--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B0_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B0_MX048_NX048_KX08_src.cpp
@@ -18,7 +18,7 @@ const unsigned int dgemm_Col_NN_B0_MX048_NX048_KX08_microTileNumCols = 6;
 const unsigned int dgemm_Col_NN_B0_MX048_NX048_KX08_unroll = 8;
 
 const char * const dgemm_Col_NN_B0_MX048_NX048_KX08_src = STRINGIFY(
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable \n
+_Pragma("OPENCL EXTENSION cl_khr_fp64 : enable") \n
 
 #define  M6x6 \
             rA[0] = lA[offA + 0];\

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B1_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NN_B1_MX048_NX048_KX08_src.cpp
@@ -18,7 +18,7 @@ const unsigned int dgemm_Col_NN_B1_MX048_NX048_KX08_microTileNumCols = 6;
 const unsigned int dgemm_Col_NN_B1_MX048_NX048_KX08_unroll = 8;
 
 const char * const dgemm_Col_NN_B1_MX048_NX048_KX08_src = STRINGIFY(
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable   \n
+_Pragma("OPENCL EXTENSION cl_khr_fp64 : enable")   \n
 
 #define  M6x6 \
             rA[0] = lA[offA + 0];                       \

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B0_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B0_MX048_NX048_KX08_src.cpp
@@ -18,7 +18,7 @@ const unsigned int dgemm_Col_NT_B0_MX048_NX048_KX08_microTileNumCols = 6;
 const unsigned int dgemm_Col_NT_B0_MX048_NX048_KX08_unroll = 8;
 
 const char * const dgemm_Col_NT_B0_MX048_NX048_KX08_src = STRINGIFY(
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable   \n
+_Pragma("OPENCL EXTENSION cl_khr_fp64 : enable")   \n
 \n
 \ntypedef union _GPtr {
 \n  __global float *f;

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B1_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_NT_B1_MX048_NX048_KX08_src.cpp
@@ -18,7 +18,7 @@ const unsigned int dgemm_Col_NT_B1_MX048_NX048_KX08_microTileNumCols = 6;
 const unsigned int dgemm_Col_NT_B1_MX048_NX048_KX08_unroll = 8;
 
 const char * const dgemm_Col_NT_B1_MX048_NX048_KX08_src = STRINGIFY(
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable   \n
+_Pragma("OPENCL EXTENSION cl_khr_fp64 : enable")   \n
 \n
 \ntypedef union _GPtr {
 \n  __global float *f;

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B0_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B0_MX048_NX048_KX08_src.cpp
@@ -18,7 +18,7 @@ const unsigned int dgemm_Col_TN_B0_MX048_NX048_KX08_microTileNumCols = 6;
 const unsigned int dgemm_Col_TN_B0_MX048_NX048_KX08_unroll = 8;
 
 const char * const dgemm_Col_TN_B0_MX048_NX048_KX08_src = STRINGIFY(
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable   \n
+_Pragma("OPENCL EXTENSION cl_khr_fp64 : enable")   \n
 
 __attribute__( (reqd_work_group_size(8, 8, 1)) )
 __kernel void dgemm_Col_TN_B0_MX048_NX048_KX08_src (

--- a/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B1_MX048_NX048_KX08_src.cpp
+++ b/src/library/blas/AutoGemm/UserGemmKernelSources/dgemm_Col_TN_B1_MX048_NX048_KX08_src.cpp
@@ -18,7 +18,7 @@ const unsigned int dgemm_Col_TN_B1_MX048_NX048_KX08_microTileNumCols = 6;
 const unsigned int dgemm_Col_TN_B1_MX048_NX048_KX08_unroll = 8;
 
 const char * const dgemm_Col_TN_B1_MX048_NX048_KX08_src = STRINGIFY(
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable   \n
+_Pragma("OPENCL EXTENSION cl_khr_fp64 : enable")   \n
 
 __attribute__( (reqd_work_group_size(8, 8, 1)) )
 __kernel void dgemm_Col_TN_B1_MX048_NX048_KX08_src (


### PR DESCRIPTION
… not allow compilation of the code otherwise (found on FreeBSD-CURRENT).

The solution employed here is equivalent to the one used in #189.