### PR TITLE
Only use the "-m32" or "-m64" compiler flags on x86.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -296,9 +296,17 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     # Don't use -rpath.
     set(CMAKE_SKIP_RPATH ON CACHE BOOL "Skip RPATH" FORCE)
 
-    set(CMAKE_C_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_Fortran_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_Fortran_FLAGS}")
+    # Need to determine the target machine of the C compiler, because
+    # the '-m32' and '-m64' flags are supported on x86 but not on e.g. ARM.
+    exec_program( "${CMAKE_C_COMPILER} -dumpmachine"
+        OUTPUT_VARIABLE CMAKE_C_COMPILER_MACHINE )
+    message( STATUS "CMAKE_C_COMPILER_MACHINE: ${CMAKE_C_COMPILER_MACHINE}" )
+    # The "86" regular expression matches x86, x86_64, i686, etc.
+    if(${CMAKE_C_COMPILER_MACHINE} MATCHES "86")
+        set(CMAKE_C_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_Fortran_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_Fortran_FLAGS}")
+    endif()
 
     if(TARGET_PLATFORM EQUAL 32)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-builtin")


### PR DESCRIPTION
The following sets up either the "-m32" or "-m64" compiler flag depending on the pointer size:
```
        set(CMAKE_C_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_C_FLAGS}")
        set(CMAKE_CXX_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_CXX_FLAGS}")
        set(CMAKE_Fortran_FLAGS "-m${TARGET_PLATFORM} ${CMAKE_Fortran_FLAGS}")
```
Unfortunately, this appears to be x86 specific. 

For example, my local GNU compiler for ARM does not support it:
```
$ gcc --version
gcc (Gentoo 5.3.0 p1.0, pie-0.6.5) 5.3.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
$ gcc -dumpmachine
armv7a-hardfloat-linux-gnueabi
$ gcc -m32
gcc: error: unrecognized command line option '-m32'
```
That's why I propose to use the "-dumpmachine" flag to get the target machine of the GNU compiler first. Then only use the flags if the returned string contains "86" (which matches, for example, both "x86_64" and "i586").

Thanks!