### PR TITLE
documentation update: xgemm and s/d trsm are no longer thread-safe. 

### DIFF
--- a/doc/clBLAS.doxy
+++ b/doc/clBLAS.doxy
@@ -32,7 +32,7 @@ PROJECT_NAME           = clBLAS
 # This could be handy for archiving the generated documentation or 
 # if some version control system is used.
 
-PROJECT_NUMBER         = 2.0
+PROJECT_NUMBER         = 2.11
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description 
 # for a project that appears at the top of each page and should give viewer 

--- a/src/clAmdBlas.h
+++ b/src/clAmdBlas.h
@@ -8308,6 +8308,7 @@ clAmdBlasZtbsv(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with float
  * elements.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8407,6 +8408,7 @@ clAmdBlasSgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with double
  * elements.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8479,6 +8481,7 @@ clAmdBlasDgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with float
  * complex elements.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8547,6 +8550,7 @@ clAmdBlasCgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with double
  * complex elements.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8615,6 +8619,7 @@ clAmdBlasZgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with float
  *        elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8704,6 +8709,7 @@ clAmdBlasSgemmEx(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with double
  *        elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8785,6 +8791,7 @@ clAmdBlasDgemmEx(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with float
  *        complex elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -8864,6 +8871,7 @@ clAmdBlasCgemmEx(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with double
  *        complex elements. Exteneded version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -9552,6 +9560,7 @@ clAmdBlasZtrmmEx(
 /**
  * @brief Solving triangular systems of equations with multiple right-hand
  * sides and float elements.
+ * @note This function is not thread-safe.
  *
  * Solving triangular systems of equations:
  *   - \f$ B \leftarrow \alpha A^{-1} B \f$
@@ -9647,6 +9656,7 @@ clAmdBlasStrsm(
 /**
  * @brief Solving triangular systems of equations with multiple right-hand
  * sides and double elements.
+ * @note This function is not thread-safe.
  *
  * Solving triangular systems of equations:
  *   - \f$ B \leftarrow \alpha A^{-1} B \f$
@@ -9847,6 +9857,7 @@ clAmdBlasZtrsm(
 /**
  * @brief Solving triangular systems of equations with multiple right-hand
  *        sides and float elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Solving triangular systems of equations:
  *   - \f$ B \leftarrow \alpha A^{-1} B \f$
@@ -9929,6 +9940,7 @@ clAmdBlasStrsmEx(
 /**
  * @brief Solving triangular systems of equations with multiple right-hand
  *        sides and double elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Solving triangular systems of equations:
  *   - \f$ B \leftarrow \alpha A^{-1} B \f$

--- a/src/clAmdBlas.version.h
+++ b/src/clAmdBlas.version.h
@@ -18,5 +18,5 @@
 /* the configured version and settings for clblas
  */
 #define clAmdBlasVersionMajor 2
-#define clAmdBlasVersionMinor 0
+#define clAmdBlasVersionMinor 10
 #define clAmdBlasVersionPatch 0

--- a/src/clAmdBlas.version.h
+++ b/src/clAmdBlas.version.h
@@ -18,5 +18,5 @@
 /* the configured version and settings for clblas
  */
 #define clAmdBlasVersionMajor 2
-#define clAmdBlasVersionMinor 10
+#define clAmdBlasVersionMinor 0
 #define clAmdBlasVersionPatch 0

--- a/src/clBLAS.h
+++ b/src/clBLAS.h
@@ -56,8 +56,10 @@ extern "C" {
  * keeping interfaces familiar to users who know how to use BLAS. All
  * functions accept matrices through buffer objects.
  *
- * This library is entirely thread-safe with the exception of the following API :
- * clblasSetup and clblasTeardown. 
+ * This library is thread-safe with the exception of the following API :
+ * clblasSetup and clblasTeardown, clblasXgemm, clblasStrsm, clblasDtrsm.
+ * clblasXgemm is no longer thread-safe due to Auto-Gemm.
+ * clblasStrsm and clblasDtrsm rely on clblasXgemm. But clblasCtrsm and clblasZtrsm are still thread-safe.  
  * Developers using the library can safely using any blas routine from different thread. 
  *
  * @section deprecated
@@ -7327,6 +7329,7 @@ clblasZtbsv(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with float
  *        elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -7412,6 +7415,7 @@ clblasSgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with double
  *        elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -7488,6 +7492,7 @@ clblasDgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with float
  *        complex elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -7562,6 +7567,7 @@ clblasCgemm(
 /**
  * @brief Matrix-matrix product of general rectangular matrices with double
  *        complex elements. Exteneded version.
+ * @note This function is not thread-safe.
  *
  * Matrix-matrix products:
  *   - \f$ C \leftarrow \alpha A B + \beta C \f$
@@ -7938,6 +7944,7 @@ clblasZtrmm(
 /**
  * @brief Solving triangular systems of equations with multiple right-hand
  *        sides and float elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Solving triangular systems of equations:
  *   - \f$ B \leftarrow \alpha A^{-1} B \f$
@@ -8015,6 +8022,7 @@ clblasStrsm(
 /**
  * @brief Solving triangular systems of equations with multiple right-hand
  *        sides and double elements. Extended version.
+ * @note This function is not thread-safe.
  *
  * Solving triangular systems of equations:
  *   - \f$ B \leftarrow \alpha A^{-1} B \f$


### PR DESCRIPTION
update version number to 2.11

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/228)
<!-- Reviewable:end -->
