### PR TITLE
Update .travis.yml and appveyor.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,19 +113,21 @@ install:
   - if [ ${TRAVIS_OS_NAME} == "linux" ]; then
       mkdir -p ${OPENCL_ROOT};
       pushd ${OPENCL_ROOT};
-      wget ${OPENCL_REGISTRY}/specs/opencl-icd-1.2.11.0.tgz;
-      tar -xf opencl-icd-1.2.11.0.tgz;
-      mv ./icd/* .;
-      mkdir -p inc/CL;
+      travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git;
+      mv ./OpenCL-ICD-Loader/* .;
+      travis_retry git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git inc/CL;
       pushd inc/CL;
-      wget -r -w 1 -np -nd -nv -A h,hpp https://www.khronos.org/registry/cl/api/1.2/;
-      wget -w 1 -np -nd -nv -A h,hpp https://www.khronos.org/registry/cl/api/2.1/cl.hpp;
+      travis_retry wget -w 1 -np -nd -nv -A h,hpp ${OPENCL_REGISTRY}/api/2.1/cl.hpp;
       popd;
       mkdir -p lib;
       pushd lib;
       cmake -G "Unix Makefiles" ..;
       make;
-      cp ../bin/libOpenCL.so .;
+      cp ./bin/libOpenCL.so .;
+      popd;
+      pushd inc/CL;
+      travis_retry git fetch origin opencl12:opencl12;
+      git checkout opencl12;
       popd;
       mv inc/ include/;
       popd;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,15 +40,14 @@ install:
   - ps: mkdir $env:OPENCL_ROOT
   - ps: pushd $env:OPENCL_ROOT
   - ps: $opencl_registry = $env:OPENCL_REGISTRY
-  # This downloads the source to the example/demo icd library
-  - ps: wget $opencl_registry/specs/opencl-icd-1.2.11.0.tgz -OutFile opencl-icd-1.2.11.0.tgz
-  - ps: 7z x opencl-icd-1.2.11.0.tgz
-  - ps: 7z x opencl-icd-1.2.11.0.tar
-  - ps: mv .\icd\* .
+  # This downloads the source to the Khronos ICD library
+  - git clone --depth 1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+  - ps: mv ./OpenCL-ICD-Loader/* .
   # This downloads all the opencl header files
   # The cmake build files expect a directory called inc
   - ps: mkdir inc/CL
-  - ps: wget $opencl_registry/api/1.2/ | select -ExpandProperty links | where {$_.href -like "*.h*"} | select -ExpandProperty outerText | foreach{ wget $opencl_registry/api/1.2/$_ -OutFile inc/CL/$_ }
+  - git clone --depth 1 https://github.com/KhronosGroup/OpenCL-Headers.git inc/CL
+  - ps: wget $opencl_registry/api/2.1/cl.hpp -OutFile inc/CL/cl.hpp
   # - ps: dir; if( $lastexitcode -eq 0 ){ dir include/CL } else { Write-Output boom }
   # Create the static import lib in a directory called lib, so findopencl() will find it
   - ps: mkdir lib
@@ -56,9 +55,13 @@ install:
   - cmake -G "NMake Makefiles" ..
   - nmake
   - ps: popd
+  # Switch to OpenCL 1.2 headers
+  - ps: pushd inc/CL
+  - git fetch origin opencl12:opencl12
+  - git checkout opencl12
+  - ps: popd
   # Rename the inc directory to include, so FindOpencl() will find it
   - ps: ren inc include
-  - ps: popd
   - ps: popd
 
 # before_build is used to run configure steps


### PR DESCRIPTION
OpenCL headers were moved to Github (https://github.com/KhronosGroup/OpenCL-Headers/) and are no longer available at https://www.khronos.org/registry/cl/api/.