### PR TITLE
fix the compilation bug about c(z)dotc_ in issue #142 and issue #184.

### DIFF
--- a/src/tests/correctness/blas-lapack.c
+++ b/src/tests/correctness/blas-lapack.c
@@ -655,7 +655,7 @@ complex cdotu( int n, complex *x, int incx, complex *y, int incy)
     #elif defined( __APPLE__)
         cblas_cdotu_sub(n, x, incx, y, incy, &ans);
     #else
-        cdotusub_(&n, x, &incx, y, &incy, &ans);
+        ans = cdotu_(&n, x, &incx, y, &incy);
     #endif
 
     return ans;
@@ -670,7 +670,7 @@ doublecomplex zdotu( int n, doublecomplex *x, int incx,  doublecomplex *y, int i
     #elif defined(__APPLE__)
         cblas_zdotu_sub(n, x, incx, y, incy, &ans);
     #else
-        zdotusub_(&n, x, &incx, y, &incy, &ans);
+        ans = zdotu_(&n, x, &incx, y, &incy);
     #endif
 
     return ans;
@@ -685,7 +685,7 @@ complex cdotc( int n, complex *x, int incx, complex *y, int incy)
     #elif defined(__APPLE__)
         cblas_cdotc_sub(n, x, incx, y, incy, &ans);
     #else
-        cdotcsub_(&n, x, &incx, y, &incy, &ans);
+        ans = cdotc_(&n, x, &incx, y, &incy);
     #endif
 
     return ans;
@@ -700,7 +700,7 @@ doublecomplex zdotc( int n, doublecomplex *x, int incx,  doublecomplex *y, int i
     #elif defined(__APPLE__)
         cblas_zdotc_sub(n, x, incx, y, incy, &ans);
     #else
-        zdotcsub_(&n, x, &incx, y, &incy, &ans);
+        ans = zdotc_(&n, x, &incx, y, &incy);
     #endif
 
     return ans;


### PR DESCRIPTION
 In clblas' "blas-lapack.c" , "cdotu" call "cdotusub_" in linux branch. 
 Yet, in fact, it is unnecessary since there is a "cdotu" routine implementation in BLAS. 
 Similar reason applies on cdotu, zdotu,zdotc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/242)
<!-- Reviewable:end -->
