### PR TITLE
fixed compareMatrices to use GTEST_FLOAT_EQ

### DIFF
--- a/src/tests/common.cpp
+++ b/src/tests/common.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <string.h>
 #include <clBLAS.h>
+#include <gtest/gtest.h>
 
 #include <common.h>
 
@@ -1015,4 +1016,24 @@ functionBlasLevel(BlasFunctionID funct) {
     default:
         return 0;
     }
+}
+
+
+template<>
+void gtestAssertElementsEqual( const float & a, const float & b) {
+  ASSERT_FLOAT_EQ(a, b);
+}
+template<>
+void gtestAssertElementsEqual( const double & a, const double & b) {
+  ASSERT_DOUBLE_EQ(a, b);
+}
+template<>
+void gtestAssertElementsEqual( const FloatComplex & a, const FloatComplex & b) {
+  ASSERT_FLOAT_EQ(CREAL(a), CREAL(b));
+  ASSERT_FLOAT_EQ(CIMAG(a), CIMAG(b));
+}
+template<>
+void gtestAssertElementsEqual( const DoubleComplex & a, const DoubleComplex & b) {
+  ASSERT_DOUBLE_EQ(CREAL(a), CREAL(b));
+  ASSERT_DOUBLE_EQ(CIMAG(a), CIMAG(b));
 }

--- a/src/tests/include/common.h
+++ b/src/tests/include/common.h
@@ -692,6 +692,10 @@ printTestParams(
     size_t offx,
     int incx);
 
+
+template<typename T>
+void gtestAssertElementsEqual( const T & a, const T & b);
+
 #endif  // __cplusplus
 
 #endif  /* COMMON_H_ */

--- a/src/tests/include/matrix.h
+++ b/src/tests/include/matrix.h
@@ -298,6 +298,7 @@ reorderMatrix(
     }
 }
 
+
 template <typename T>
 static void
 compareMatrices(
@@ -315,207 +316,41 @@ compareMatrices(
 
     if( lda > 0 ) // General case
     {
-    for (m = 0; m < M; m++) {
-        for (n = 0; n < N; n++) {
-            a = getElement<T>(order, clblasNoTrans, m, n, A, lda);
-            b = getElement<T>(order, clblasNoTrans, m, n, B, lda);
-            delta = 0.0;
-            if (absDelta != NULL) {
-                delta = absDelta[m * N + n];
+        for (m = 0; m < M; m++) {
+            for (n = 0; n < N; n++) {
+                a = getElement<T>(order, clblasNoTrans, m, n, A, lda);
+                b = getElement<T>(order, clblasNoTrans, m, n, B, lda);
+                gtestAssertElementsEqual(a, b);
             }
-			if( module(a-b) > delta )		printf("m : %d\t n: %d\n", (int)m, (int)n);
-            ASSERT_NEAR(a, b, delta);
         }
-    }
     }
     else // Packed case
     {
-	if ( order == clblasColumnMajor)
-	{
-		for ( n = 0; n < N; n++)
-		{
-			for( m=n; m < M; m++)
-			{
-            			a = getElement<T>(order, clblasNoTrans, m, n, A, lda);
-			        b = getElement<T>(order, clblasNoTrans, m, n, B, lda);
-            			delta = 0.0;
-            			if (absDelta != NULL) {
-                			//delta = absDelta[m * N + n];
-            			}
-						if( module(a-b) > delta )		printf("m : %d\t n: %d\n", (int)m, (int)n);
-            			ASSERT_NEAR(a, b, delta);
-			}
-		}
-	}
-	else
-	{
-		for ( m = 0; m < M; m++)
-		{
-			for( n = 0; n <= m; n++)
-			{
-            			a = getElement<T>(order, clblasNoTrans, m, n, A, lda);
-			        b = getElement<T>(order, clblasNoTrans, m, n, B, lda);
-            			delta = 0.0;
-            			if (absDelta != NULL) {
-                			//delta = absDelta[m * N + n];
-            			}
-						if( module(a-b) > delta )		printf("m : %d\t n: %d\n", (int)m, (int)n);
-            			ASSERT_NEAR(a, b, delta);
-			}
-		}
-	}
-    }
-}
-
-template<>
-__template_static void
-compareMatrices<FloatComplex>(
-    clblasOrder order,
-    size_t M,
-    size_t N,
-    const FloatComplex *A,
-    const FloatComplex *B,
-    size_t lda,
-    const cl_double *absDelta)
-{
-    size_t m = 0, n = 0;
-    FloatComplex a, b;
-    cl_double delta;
-
-if ( lda > 0 )
-{
-    for (m = 0; m < M; m++) {
-        for (n = 0; n < N; n++) {
-            a = getElement<FloatComplex>(order, clblasNoTrans, m, n, A, lda);
-            b = getElement<FloatComplex>(order, clblasNoTrans, m, n, B, lda);
-            delta = 0.0;
-            if (absDelta != NULL) {
-                delta = absDelta[m * N + n];
+        if ( order == clblasColumnMajor)
+        {
+            for ( n = 0; n < N; n++)
+            {
+                for( m=n; m < M; m++)
+                {
+                    a = getElement<T>(order, clblasNoTrans, m, n, A, lda);
+                    b = getElement<T>(order, clblasNoTrans, m, n, B, lda);
+                    gtestAssertElementsEqual(a, b);
+                }
             }
-			if( (module(CREAL(a) - CREAL(b)) > delta) || (module(CIMAG(a) - CIMAG(b)) > delta) )
-					printf("m : %d\t n: %d\n", (int)m, (int)n);
-            ASSERT_NEAR(CREAL(a), CREAL(b), delta);
-            ASSERT_NEAR(CIMAG(a), CIMAG(b), delta);
+        }
+        else
+        {
+            for ( m = 0; m < M; m++)
+            {
+                for( n = 0; n <= m; n++)
+                {
+                    a = getElement<T>(order, clblasNoTrans, m, n, A, lda);
+                    b = getElement<T>(order, clblasNoTrans, m, n, B, lda);
+                    gtestAssertElementsEqual(a, b);
+                }
+            }
         }
     }
-}
-    else // Packed case
-    {
-	if ( order == clblasColumnMajor)
-	{
-		for ( n = 0; n < N; n++)
-		{
-			for( m=n; m < M; m++)
-			{
-            			a = getElement<FloatComplex>(order, clblasNoTrans, m, n, A, lda);
-				        b = getElement<FloatComplex>(order, clblasNoTrans, m, n, B, lda);
-            			delta = 0.0;
-            			if (absDelta != NULL) {
-                			//delta = absDelta[m * N + n];
-            			}
-            			if( (module(CREAL(a) - CREAL(b)) > delta) || (module(CIMAG(a) - CIMAG(b)) > delta) )
-							printf("m : %d\t n: %d\n", (int)m, (int)n);
-            			ASSERT_NEAR(CREAL(a), CREAL(b), delta);
-		            	ASSERT_NEAR(CIMAG(a), CIMAG(b), delta);
-			}
-		}
-	}
-	else
-	{
-		for ( m = 0; m < M; m++)
-		{
-			for( n = 0; n <= m; n++)
-			{
-            			a = getElement<FloatComplex>(order, clblasNoTrans, m, n, A, lda);
-			        b = getElement<FloatComplex>(order, clblasNoTrans, m, n, B, lda);
-            			delta = 0.0;
-            			if (absDelta != NULL) {
-                			//delta = absDelta[m * N + n];
-            			}
-						if( (module(CREAL(a) - CREAL(b)) > delta) || (module(CIMAG(a) - CIMAG(b)) > delta) )
-							printf("m : %d\t n: %d\n", (int)m, (int)n);
-            			ASSERT_NEAR(CREAL(a), CREAL(b), delta);
-		            	ASSERT_NEAR(CIMAG(a), CIMAG(b), delta);
-			}
-		}
-	}
-    }
-
-}
-
-template<>
-__template_static void
-compareMatrices<DoubleComplex>(
-    clblasOrder order,
-    size_t M,
-    size_t N,
-    const DoubleComplex *A,
-    const DoubleComplex *B,
-    size_t lda,
-    const cl_double *absDelta)
-{
-    size_t m = 0, n = 0;
-    DoubleComplex a, b;
-    cl_double delta;
-if( lda > 0 )
-{
-    for (m = 0; m < M; m++) {
-        for (n = 0; n < N; n++) {
-            a = getElement<DoubleComplex>(order, clblasNoTrans, m, n, A, lda);
-            b = getElement<DoubleComplex>(order, clblasNoTrans, m, n, B, lda);
-            delta = 0.0;
-            if (absDelta != NULL) {
-                delta = absDelta[m * N + n];
-            }
-			if( (module(CREAL(a) - CREAL(b)) > delta) || (module(CIMAG(a) - CIMAG(b)) > delta) )
-					printf("m : %d\t n: %d\n", (int)m, (int)n);
-            ASSERT_NEAR(CREAL(a), CREAL(b), delta);
-            ASSERT_NEAR(CIMAG(a), CIMAG(b), delta);
-        }
-    }
-}
-    else // Packed case
-    {
-	if ( order == clblasColumnMajor)
-	{
-		for ( n = 0; n < N; n++)
-		{
-			for( m=n; m < M; m++)
-			{
-            			a = getElement<DoubleComplex>(order, clblasNoTrans, m, n, A, lda);
-			        b = getElement<DoubleComplex>(order, clblasNoTrans, m, n, B, lda);
-            			delta = 0.0;
-            			if (absDelta != NULL) {
-                			//delta = absDelta[m * N + n];
-            			}
-						if( (module(CREAL(a) - CREAL(b)) > delta) || (module(CIMAG(a) - CIMAG(b)) > delta) )
-							printf("m : %d\t n: %d\n", (int)m, (int)n);
-            			ASSERT_NEAR(CREAL(a), CREAL(b), delta);
-		            	ASSERT_NEAR(CIMAG(a), CIMAG(b), delta);
-			}
-		}
-	}
-	else
-	{
-		for ( m = 0; m < M; m++)
-		{
-			for( n = 0; n <= m; n++)
-			{
-            			a = getElement<DoubleComplex>(order, clblasNoTrans, m, n, A, lda);
-			        b = getElement<DoubleComplex>(order, clblasNoTrans, m, n, B, lda);
-            			delta = 0.0;
-            			if (absDelta != NULL) {
-                			//delta = absDelta[m * N + n];
-            			}
-						if( (module(CREAL(a) - CREAL(b)) > delta) || (module(CIMAG(a) - CIMAG(b)) > delta) )
-							printf("m : %d\t n: %d\n", (int)m, (int)n);
-            			ASSERT_NEAR(CREAL(a), CREAL(b), delta);
-		            	ASSERT_NEAR(CIMAG(a), CIMAG(b), delta);
-			}
-		}
-	}
-    }
-
 }
 
 template <typename T>


### PR DESCRIPTION
old gtest code was using float == float and double == double, new code uses GTEST_FLOAT_EQ(a,b) and GTEST_DOUBLE_EQ(a,b) which compares to whithin 4ulps. Better written code also reduces a lot of duplicate code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/245)
<!-- Reviewable:end -->
