### PR TITLE
fix error with missing KernelName variable

### DIFF
--- a/src/library/blas/xgemm.cc
+++ b/src/library/blas/xgemm.cc
@@ -271,7 +271,7 @@ void makeGemmKernel(
 	CL_CHECK(err)
 
 #ifdef AUTOGEMM_PRINT_DEBUG
-    printf("makeGemmKernel: \"%s\" now built; returning.\n", kernelName);
+    printf("makeGemmKernel now built; returning.\n");
 #endif
 
     //put kernel in map


### PR DESCRIPTION
kernelname missing, so if you build with AUTOGEMM_PRINT_DEBUG defined, there is a build error at line 274 of xgemm.cc.  This PR fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/249)
<!-- Reviewable:end -->
