### PR TITLE
For discussion: fix memory leak with xgemm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,5 @@
 # vim temp files
 .*.swp
 
-src/build/
+src/build*/
 

--- a/src/library/blas/include/xgemm.h
+++ b/src/library/blas/include/xgemm.h
@@ -31,6 +31,8 @@ void makeGemmKernel(
 	const unsigned char **kernelBinary,
 	size_t *kernelBinarySize,
 	const char *binaryBuildOptions);
+void xgemmInit();
+void xgemmTeardown();
 
 #ifdef __cplusplus
 }

--- a/src/library/blas/init.c
+++ b/src/library/blas/init.c
@@ -258,9 +258,8 @@ clblasTeardown(void)
     releaseMallocTrace();
 
 #ifdef BUILDING_CLBLAS
-   initUserGemmClKernels();
-   initAutoGemmClKernels();
    xgemmTeardown();
+   initAutoGemmClKernels();
 #endif
 
     clblasInitialized = 0;

--- a/src/library/blas/init.c
+++ b/src/library/blas/init.c
@@ -28,6 +28,7 @@
 #ifdef BUILDING_CLBLAS
 #include "AutoGemmTeardown.h"
 #include "UserGemmClKernels.h"
+#include "xgemm.h"
 #endif
 
 clblasStatus
@@ -203,6 +204,10 @@ clblasSetup(void)
 		kCacheLimit *= (1024 * 1024);
 	}
 
+#ifdef BUILDING_CLBLAS
+  xgemmInit();
+#endif
+
     if (kCacheLimit || (tmp == NULL)) {
         clblasKernelCache = createKernelCache(sidsNum, kCacheLimit);
     	if (clblasKernelCache == NULL) {
@@ -217,7 +222,6 @@ clblasSetup(void)
     decomposeEventsSetup();
 
     initStorageCache();
-
     clblasInitialized = 1;
     return clblasSuccess;
 }
@@ -235,7 +239,6 @@ clblasTeardown(void)
     if (!clblasInitialized) {
         return;
     }
-
     printMallocStatistics();
 
     if (clblasKernelCache != NULL) {
@@ -257,6 +260,7 @@ clblasTeardown(void)
 #ifdef BUILDING_CLBLAS
    initUserGemmClKernels();
    initAutoGemmClKernels();
+   xgemmTeardown();
 #endif
 
     clblasInitialized = 0;


### PR DESCRIPTION
This addresses a memory leak in xgemm, which causes the cl context to not be released during teardown, consuming ~50-70MB per setup/release cycle, https://github.com/clMathLibraries/clBLAS/issues/247

I've labelled this as 'for discussion', since it's not thread safe.  It is however suitable for my own use, but it should hvae some mutexes or similar to work for multi-threading scenarios.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/250)

<!-- Reviewable:end -->
