### PR TITLE
Support for altivec on powerpc64 P8 systems

### DIFF
--- a/src/include/defbool.h
+++ b/src/include/defbool.h
@@ -18,6 +18,11 @@
 #ifndef DEFBOOL_H_
 #define DEFBOOL_H_
 
+#if defined(__powerpc64__) && defined(__ALTIVEC__)
+#include "altivec.h"
+#undef bool
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER <= 1700
 
 /*

--- a/src/library/blas/functor/functor_xscal.cc
+++ b/src/library/blas/functor/functor_xscal.cc
@@ -81,7 +81,7 @@ doScal(
   kargs->N = N;
   kargs->A = X;
   kargs->offBX = offx;
-  kargs->ldb.vector = incx;	// Will be using this as incx
+  kargs->ldb.Vector = incx;	// Will be using this as incx
 
   if(incx < 0) {    // According to Netlib - return for negative incx
     return clblasSuccess;

--- a/src/library/blas/generic/solution_seq_make.c
+++ b/src/library/blas/generic/solution_seq_make.c
@@ -709,10 +709,10 @@ clblasArgsToKextraFlags(const CLBlasKargs *args, BlasFunctionID funcID)
         }
     }
     if (funcID == CLBLAS_GEMV || funcID == CLBLAS_SYMV) {
-        if (args->ldb.vector == 1) {
+        if (args->ldb.Vector == 1) {
             flags |= KEXTRA_INCX_ONE;
         }
-        if (args->ldc.vector == 1) {
+        if (args->ldc.Vector == 1) {
             flags |= KEXTRA_INCY_ONE;
         }
     }

--- a/src/library/blas/gens/asum.cpp
+++ b/src/library/blas/gens/asum.cpp
@@ -137,10 +137,10 @@ setBuildOpts(
 		printf("Setting build options ... Double... for DOUBLE PRECISION support\n");
 		#endif
 	}
-    if( (kargs->ldb.vector) != 1) {
+    if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldb.vector) < 1) {
+    if( (kargs->ldb.Vector) < 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NEGATIVE");
     }
 	return;
@@ -275,7 +275,7 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[1], blasArgs->D);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
 	return;
 }

--- a/src/library/blas/gens/axpy_reg.cpp
+++ b/src/library/blas/gens/axpy_reg.cpp
@@ -130,10 +130,10 @@ setBuildOpts(
 		printf("Setting build options ... Double... for DOUBLE PRECISION support\n");
 		#endif
 	}
-	if( (kargs->ldb.vector) != 1) {
+	if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldc.vector) != 1) {
+    if( (kargs->ldc.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCY_NONUNITY");
     }
 
@@ -269,10 +269,10 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[2], blasArgs->B);
     initSizeKarg(&args[3], blasArgs->N);
     initSizeKarg(&args[4], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[5], incx);
     initSizeKarg(&args[6], blasArgs->offCY);
-    incy = blasArgs->ldc.vector;
+    incy = blasArgs->ldc.Vector;
     INIT_KARG(&args[7], incy);
 
 	return;

--- a/src/library/blas/gens/copy_reg.cpp
+++ b/src/library/blas/gens/copy_reg.cpp
@@ -130,10 +130,10 @@ setBuildOpts(
 		printf("Setting build options ... Double... for DOUBLE PRECISION support\n");
 		#endif
 	}
-	if( (kargs->ldb.vector) != 1) {
+	if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldc.vector) != 1) {
+    if( (kargs->ldc.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCY_NONUNITY");
     }
 
@@ -264,10 +264,10 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[1], blasArgs->B);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
     initSizeKarg(&args[5], blasArgs->offCY);
-    incy = blasArgs->ldc.vector;
+    incy = blasArgs->ldc.Vector;
     INIT_KARG(&args[6], incy);
 
 	return;

--- a/src/library/blas/gens/dot.cpp
+++ b/src/library/blas/gens/dot.cpp
@@ -133,10 +133,10 @@ setBuildOpts(
 		printf("Setting build options ... Double... for DOUBLE PRECISION support\n");
 		#endif
 	}
-    if( (kargs->ldb.vector) != 1) {
+    if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldc.vector) != 1) {
+    if( (kargs->ldc.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCY_NONUNITY");
     }
 
@@ -272,10 +272,10 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[2], blasArgs->D);
     initSizeKarg(&args[3], blasArgs->N);
     initSizeKarg(&args[4], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[5], incx);
     initSizeKarg(&args[6], blasArgs->offCY);
-    incy = blasArgs->ldc.vector;
+    incy = blasArgs->ldc.Vector;
     INIT_KARG(&args[7], incy);
     doConj = blasArgs->K;
     INIT_KARG(&args[8], doConj);

--- a/src/library/blas/gens/gbmv.cpp
+++ b/src/library/blas/gens/gbmv.cpp
@@ -389,9 +389,9 @@ assignKargs(KernelArg *args, const void *params, const void* )
     initSizeKarg(&args[6], fKU);
 
     initSizeKarg(&args[7], blasArgs->lda.matrix);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[8], inc);
-    inc = blasArgs->ldc.vector;
+    inc = blasArgs->ldc.Vector;
     INIT_KARG(&args[9], inc);
 
 	initSizeKarg(&args[10], blasArgs->offa);

--- a/src/library/blas/gens/gemv.c
+++ b/src/library/blas/gens/gemv.c
@@ -434,12 +434,12 @@ assignKargs(KernelArg *args, const void *params, const void *extra)
         initSizeKarg(&args[i++], blasArgs->offCY);
     }
     if (!(kflags & KEXTRA_INCX_ONE)) {
-        inc = blasArgs->ldb.vector;
+        inc = blasArgs->ldb.Vector;
         INIT_KARG(&args[i], inc);
         i++;
     }
     if (!(kflags & KEXTRA_INCY_ONE)) {
-        inc = blasArgs->ldc.vector;
+        inc = blasArgs->ldc.Vector;
         INIT_KARG(&args[i], inc);
         i++;
     }
@@ -479,12 +479,12 @@ fixupArgs(void *args, SubproblemDim *subdims, void *extra)
         else {
             kargs->offA += off * kargs->lda.matrix;
         }
-        if (kargs->ldc.vector < 0) {
+        if (kargs->ldc.Vector < 0) {
             // K store the original height of the matrix A
-            kargs->offCY += (kargs->K - off) * abs(kargs->ldc.vector);
+            kargs->offCY += (kargs->K - off) * abs(kargs->ldc.Vector);
         }
         else {
-            kargs->offCY += off * kargs->ldc.vector;
+            kargs->offCY += off * kargs->ldc.Vector;
         }
     }
 

--- a/src/library/blas/gens/ger_lds.cpp
+++ b/src/library/blas/gens/ger_lds.cpp
@@ -317,8 +317,8 @@ assignKargs(KernelArg *args, const void *params, const void*)
     initSizeKarg(&args[3], blasArgs->M);
 	initSizeKarg(&args[4], blasArgs->N);
 
-	incx = blasArgs->ldb.vector;
-	incy = blasArgs->ldc.vector;
+	incx = blasArgs->ldb.Vector;
+	incy = blasArgs->ldc.Vector;
 	initSizeKarg(&args[5], blasArgs->offBX);
     INIT_KARG(&args[6], incx);
 	initSizeKarg(&args[7], blasArgs->offCY);

--- a/src/library/blas/gens/her2_lds.cpp
+++ b/src/library/blas/gens/her2_lds.cpp
@@ -332,10 +332,10 @@ assignKargs(KernelArg *args, const void *params, const void*)
 	INIT_KARG(&args[2], blasArgs->C); 	//Y - y vector
 	initSizeKarg(&args[3], blasArgs->N);
 	initSizeKarg(&args[4], blasArgs->offBX);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[5], inc);
 	initSizeKarg(&args[6], blasArgs->offCY);
-	inc = blasArgs->ldc.vector;
+	inc = blasArgs->ldc.Vector;
 	INIT_KARG(&args[7], inc);
     initSizeKarg(&args[8], blasArgs->offa);
 	initSizeKarg(&args[9], blasArgs->lda.matrix);

--- a/src/library/blas/gens/her_lds.cpp
+++ b/src/library/blas/gens/her_lds.cpp
@@ -330,7 +330,7 @@ assignKargs(KernelArg *args, const void *params, const void*)
     INIT_KARG(&args[1], blasArgs->B); 	//x - x vector
     initSizeKarg(&args[2], blasArgs->N);
 	initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
     initSizeKarg(&args[5], blasArgs->offa);
 	initSizeKarg(&args[6], blasArgs->lda.matrix);

--- a/src/library/blas/gens/iamax.cpp
+++ b/src/library/blas/gens/iamax.cpp
@@ -130,12 +130,12 @@ setBuildOpts(
 		#endif
     }
 
-    if( (kargs->ldb.vector) != 1)
+    if( (kargs->ldb.Vector) != 1)
     {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
 
-    if( (kargs->ldb.vector) < 1)
+    if( (kargs->ldb.Vector) < 1)
     {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DRETURN_ON_INVALID");
     }
@@ -277,7 +277,7 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[1], blasArgs->D);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offb);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
 
 	return;

--- a/src/library/blas/gens/nrm2.cpp
+++ b/src/library/blas/gens/nrm2.cpp
@@ -139,10 +139,10 @@ setBuildOpts(
             addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DUSE_SSQ");
     }
 
-    if( (kargs->ldb.vector) != 1) {
+    if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldb.vector) < 1) {
+    if( (kargs->ldb.Vector) < 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DRETURN_ON_INVALID");
     }
 	return;
@@ -269,7 +269,7 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[1], blasArgs->D);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
 
 	return;

--- a/src/library/blas/gens/rotm_reg.cpp
+++ b/src/library/blas/gens/rotm_reg.cpp
@@ -127,10 +127,10 @@ setBuildOpts(
 	{
 	    addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DDO_ROT");
 	}
-	if( (kargs->ldb.vector) != 1) {
+	if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldc.vector) != 1) {
+    if( (kargs->ldc.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCY_NONUNITY");
     }
 
@@ -268,10 +268,10 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[1], blasArgs->B);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
     initSizeKarg(&args[5], blasArgs->offCY);
-    incy = blasArgs->ldc.vector;
+    incy = blasArgs->ldc.Vector;
     INIT_KARG(&args[6], incy);
 
     if(blasArgs->pigFuncID == CLBLAS_ROT)

--- a/src/library/blas/gens/scal_reg.cpp
+++ b/src/library/blas/gens/scal_reg.cpp
@@ -130,7 +130,7 @@ setBuildOpts(
 		printf("Setting build options ... Double... for DOUBLE PRECISION support\n");
 		#endif
 	}
-	if( (kargs->ldb.vector) != 1) {
+	if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
 
@@ -261,7 +261,7 @@ assignKargs(KernelArg *args, const void *params, const void* )
     INIT_KARG(&args[1], blasArgs->A);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
 
 	return;

--- a/src/library/blas/gens/swap_reg.cpp
+++ b/src/library/blas/gens/swap_reg.cpp
@@ -130,10 +130,10 @@ setBuildOpts(
 		printf("Setting build options ... Double... for DOUBLE PRECISION support\n");
 		#endif
 	}
-	if( (kargs->ldb.vector) != 1) {
+	if( (kargs->ldb.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCX_NONUNITY");
     }
-    if( (kargs->ldc.vector) != 1) {
+    if( (kargs->ldc.Vector) != 1) {
         addBuildOpt( buildOptStr, BUILD_OPTS_MAXLEN, "-DINCY_NONUNITY");
     }
 
@@ -265,10 +265,10 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	INIT_KARG(&args[1], blasArgs->B);
     initSizeKarg(&args[2], blasArgs->N);
     initSizeKarg(&args[3], blasArgs->offBX);
-    incx = blasArgs->ldb.vector;
+    incx = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], incx);
     initSizeKarg(&args[5], blasArgs->offCY);
-    incy = blasArgs->ldc.vector;
+    incy = blasArgs->ldc.Vector;
     INIT_KARG(&args[6], incy);
 
 	return;

--- a/src/library/blas/gens/symv.c
+++ b/src/library/blas/gens/symv.c
@@ -926,12 +926,12 @@ assignKargs(KernelArg *args, const void *params, const void *extra)
         initSizeKarg(&args[i++], blasArgs->offCY);
     }
     if (!(kflags & KEXTRA_INCX_ONE)) {
-        inc = blasArgs->ldb.vector;
+        inc = blasArgs->ldb.Vector;
         INIT_KARG(&args[i], inc);
         i++;
     }
     if (!(kflags & KEXTRA_INCY_ONE)) {
-        inc = blasArgs->ldc.vector;
+        inc = blasArgs->ldc.Vector;
         INIT_KARG(&args[i], inc);
         i++;
     }
@@ -949,13 +949,13 @@ fixupArgs(void *args, SubproblemDim *subdims, void *extra)
     (void)subdims;
 
     if (kargs->offsetN) {
-        if (kargs->ldc.vector < 0) {
+        if (kargs->ldc.Vector < 0) {
             // K store the original height of the matrix A
             kargs->offCY += (kargs->K - kargs->offsetN) *
-                            abs(kargs->ldc.vector);
+                            abs(kargs->ldc.Vector);
         }
         else {
-            kargs->offCY += kargs->offsetN * kargs->ldc.vector;
+            kargs->offCY += kargs->offsetN * kargs->ldc.Vector;
         }
     }
 }

--- a/src/library/blas/gens/syr2_lds.cpp
+++ b/src/library/blas/gens/syr2_lds.cpp
@@ -338,10 +338,10 @@ assignKargs(KernelArg *args, const void *params, const void*)
 	INIT_KARG(&args[2], blasArgs->C); 	//Y - y vector
 	initSizeKarg(&args[3], blasArgs->N);
 	initSizeKarg(&args[4], blasArgs->offBX);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[5], inc);
 	initSizeKarg(&args[6], blasArgs->offCY);
-	inc = blasArgs->ldc.vector;
+	inc = blasArgs->ldc.Vector;
 	INIT_KARG(&args[7], inc);
     initSizeKarg(&args[8], blasArgs->offa);
 	initSizeKarg(&args[9], blasArgs->lda.matrix);

--- a/src/library/blas/gens/syr_lds.cpp
+++ b/src/library/blas/gens/syr_lds.cpp
@@ -337,7 +337,7 @@ assignKargs(KernelArg *args, const void *params, const void*)
     INIT_KARG(&args[1], blasArgs->B); 	//x - x vector
     initSizeKarg(&args[2], blasArgs->N);
 	initSizeKarg(&args[3], blasArgs->offBX);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], inc);
     initSizeKarg(&args[5], blasArgs->offA);
 	initSizeKarg(&args[6], blasArgs->lda.matrix);

--- a/src/library/blas/gens/trmv_reg.cpp
+++ b/src/library/blas/gens/trmv_reg.cpp
@@ -426,7 +426,7 @@ assignKargs(KernelArg *args, const void *params, const void* )
     	INIT_KARG(&args[2], blasArgs->C); 	//y - scratch == _x_vector argument
     }
 	initSizeKarg(&args[3], blasArgs->N);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[4], inc);
 	unity = (blasArgs->diag == clblasUnit);
    	INIT_KARG(&args[5], unity);
@@ -444,7 +444,7 @@ assignKargs(KernelArg *args, const void *params, const void* )
 	// For HEMV both alpha and beta has to be passed.
 	if( (step->funcID == CLBLAS_HEMV) || (blasArgs->pigFuncID == CLBLAS_HPMV) || (blasArgs->pigFuncID == CLBLAS_SPMV) )
 	{
-		inc = blasArgs->ldc.vector;
+		inc = blasArgs->ldc.Vector;
 		INIT_KARG(&args[10], inc);
 		initSizeKarg(&args[11], blasArgs->offCY);
 		assignScalarKarg(&args[12], &(blasArgs->alpha), blasArgs->dtype);

--- a/src/library/blas/gens/trsv_gemv.cpp
+++ b/src/library/blas/gens/trsv_gemv.cpp
@@ -474,7 +474,7 @@ assignKargs(KernelArg *args, const void *params, const void*)
     INIT_KARG(&args[0], blasArgs->A); 	//A - input matrix - argument
     INIT_KARG(&args[1], blasArgs->B); 	//x - result buffer = _xnew argument
     initSizeKarg(&args[2], blasArgs->N);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[3], inc);
 	unity = (blasArgs->diag == clblasUnit);
    	INIT_KARG(&args[4], unity);

--- a/src/library/blas/gens/trsv_trtri.cpp
+++ b/src/library/blas/gens/trsv_trtri.cpp
@@ -382,7 +382,7 @@ assignKargs(KernelArg *args, const void *params, const void*)
     INIT_KARG(&args[0], blasArgs->A);     //A - input matrix - argument
     INIT_KARG(&args[1], blasArgs->B);     //x - result buffer = _xnew argument
     initSizeKarg(&args[2], blasArgs->N);
-    inc = blasArgs->ldb.vector;
+    inc = blasArgs->ldb.Vector;
     INIT_KARG(&args[3], inc);
     unity = (blasArgs->diag == clblasUnit);
     INIT_KARG(&args[4], unity);

--- a/src/library/blas/include/clblas-internal.h
+++ b/src/library/blas/include/clblas-internal.h
@@ -61,7 +61,7 @@ typedef union ArgMultiplier {
 
 typedef union LeadingDimention {
     size_t matrix;  /**< Positive ld value for matrixes */
-    int vector;     /**< Integer offset value for vectors */
+    int Vector;     /**< Integer offset value for vectors */
 } LeadingDimention;
 
 typedef enum reductionType {

--- a/src/library/blas/ixamax.c
+++ b/src/library/blas/ixamax.c
@@ -108,7 +108,7 @@ doiAmax(
 		kargs->N = N;
 		kargs->B = X;
         kargs->offb = offx;
-		kargs->ldb.vector = incx;   // Will be using this as incx
+		kargs->ldb.Vector = incx;   // Will be using this as incx
         if(incx < 1) {              // According to netlib, if incx<1, NRM2 will be zero
             kargs->N = 1;           // Makeing it launch only 1 work-group
         }

--- a/src/library/blas/xasum.c
+++ b/src/library/blas/xasum.c
@@ -111,7 +111,7 @@ doAsum(
         kargs->offA = offAsum;
 		kargs->B = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;   // Will be using this as incx
+		kargs->ldb.Vector = incx;   // Will be using this as incx
         if(incx <1){
             kargs->N = 1;
         }

--- a/src/library/blas/xaxpy.c
+++ b/src/library/blas/xaxpy.c
@@ -103,10 +103,10 @@ doAxpy(
 		kargs->N = N;
 		kargs->A = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 		kargs->B = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
 
 		#ifdef DEBUG_AXPY
 		printf("Calling makeSolutionSeq from DoAxpy: AXPY\n");

--- a/src/library/blas/xcopy.c
+++ b/src/library/blas/xcopy.c
@@ -96,10 +96,10 @@ doCopy(
 		kargs->N = N;
 		kargs->A = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 		kargs->B = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
 
 		#ifdef DEBUG_COPY
 		printf("Calling makeSolutionSeq from DoCopy: COPY\n");

--- a/src/library/blas/xdot.c
+++ b/src/library/blas/xdot.c
@@ -119,10 +119,10 @@ doDot(
         kargs->offa = offDP;
 		kargs->B = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;   // Will be using this as incx
+		kargs->ldb.Vector = incx;   // Will be using this as incx
 		kargs->C = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
         kargs->D = scratchBuff;
         kargs->redctnType = REDUCE_BY_SUM;
         kargs->K = (size_t)doConj;

--- a/src/library/blas/xgbmv.c
+++ b/src/library/blas/xgbmv.c
@@ -102,10 +102,10 @@ doGbmv(
     kargs->lda.matrix = lda;
     kargs->B = x;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 
     listInitHead(&seq);
     err = makeSolutionSeq(CLBLAS_GBMV, kargs, numCommandQueues, commandQueues,

--- a/src/library/blas/xgemv.c
+++ b/src/library/blas/xgemv.c
@@ -85,10 +85,10 @@ doGemv(
     kargs->lda.matrix = lda;
     kargs->B = x;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 
     listInitHead(&seq);
     err = makeSolutionSeq(CLBLAS_GEMV, kargs, numCommandQueues, commandQueues,

--- a/src/library/blas/xger.c
+++ b/src/library/blas/xger.c
@@ -121,10 +121,10 @@ doGer(
 		kargs->lda.matrix = lda;
 		kargs->B = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 		kargs->C = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
 		kargs->offsetM = 0;
 		kargs->offsetN = 0;
 		kargs->scimage[0] = 0;

--- a/src/library/blas/xhemv.c
+++ b/src/library/blas/xhemv.c
@@ -86,10 +86,10 @@ doHemv(
     kargs->lda.matrix = lda;
     kargs->B = x;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 	kargs->transA = clblasNoTrans;
 	kargs->diag = clblasNonUnit;
 

--- a/src/library/blas/xher.c
+++ b/src/library/blas/xher.c
@@ -100,7 +100,7 @@ doher(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = X;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->offBX = offx;
     kargs->offa = offa;
 	kargs->offA = offa;

--- a/src/library/blas/xher2.c
+++ b/src/library/blas/xher2.c
@@ -101,20 +101,20 @@ doHer2(
 	{
 		kargs->uplo = (uplo == clblasUpper) ? clblasLower : clblasUpper;
 		kargs->B = Y;
-		kargs->ldb.vector = incy;
+		kargs->ldb.Vector = incy;
 		kargs->offBX = offy;
 		kargs->C = X;
-		kargs->ldc.vector = incx;
+		kargs->ldc.Vector = incx;
 		kargs->offCY = offx;
 	}
 	else
 	{
 		kargs->uplo = uplo;
 		kargs->B = X;
-		kargs->ldb.vector = incx;
+		kargs->ldb.Vector = incx;
 		kargs->offBX = offx;
 		kargs->C = Y;
-		kargs->ldc.vector = incy;
+		kargs->ldc.Vector = incy;
 		kargs->offCY = offy;
 	}
     kargs->N = N;

--- a/src/library/blas/xhpmv.c
+++ b/src/library/blas/xhpmv.c
@@ -85,10 +85,10 @@ doHpmv(
     kargs->lda.matrix = 0;      // Set lda as zero for packed matrices
     kargs->B = X;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = Y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 	kargs->transA = clblasNoTrans;
 	kargs->diag = clblasNonUnit;
 

--- a/src/library/blas/xnrm2.c
+++ b/src/library/blas/xnrm2.c
@@ -219,7 +219,7 @@ doNrm2(
     kargs->offa = offNRM2;
 	kargs->B = X;
 	kargs->offBX = offx;
-	kargs->ldb.vector = incx;
+	kargs->ldb.Vector = incx;
     if(incx < 1) {              // According to netlib, if incx<1, NRM2 will be zero
         kargs->N = 1;           // Makeing it launch only 1 work-group
     }

--- a/src/library/blas/xrot.c
+++ b/src/library/blas/xrot.c
@@ -95,10 +95,10 @@ doRot(
 		kargs->N = N;
 		kargs->A = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 		kargs->B = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
 		kargs->pigFuncID = CLBLAS_ROT;  // Using ROTM kernel for ROT. Both are similar
 
 		listInitHead(&seq);

--- a/src/library/blas/xrotm.c
+++ b/src/library/blas/xrotm.c
@@ -103,10 +103,10 @@ doRotm(
 		kargs->N = N;
 		kargs->A = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 		kargs->B = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
 		kargs->D = param;
 		kargs->offd = offParam;
 		kargs->pigFuncID = CLBLAS_ROTM;

--- a/src/library/blas/xscal.c
+++ b/src/library/blas/xscal.c
@@ -87,7 +87,7 @@ doScal(
 		kargs->N = N;
 		kargs->A = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 
 		if(incx < 0) {    // According to Netlib - return for negative incx
 		    return clblasSuccess;

--- a/src/library/blas/xshbmv.c
+++ b/src/library/blas/xshbmv.c
@@ -100,10 +100,10 @@ doSHbmv(
     kargs->lda.matrix = lda;
     kargs->B = x;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 
     listInitHead(&seq);
     err = makeSolutionSeq(CLBLAS_GBMV, kargs, numCommandQueues, commandQueues,

--- a/src/library/blas/xspmv.c
+++ b/src/library/blas/xspmv.c
@@ -85,10 +85,10 @@ doSpmv(
     kargs->lda.matrix = 0;      // Set lda as zero for packed matrices
     kargs->B = X;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = Y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 
 	kargs->transA = clblasNoTrans;
 	kargs->diag = clblasNonUnit;

--- a/src/library/blas/xswap.c
+++ b/src/library/blas/xswap.c
@@ -96,10 +96,10 @@ doSwap(
 		kargs->N = N;
 		kargs->A = X;
 		kargs->offBX = offx;
-		kargs->ldb.vector = incx;	// Will be using this as incx
+		kargs->ldb.Vector = incx;	// Will be using this as incx
 		kargs->B = Y;
 		kargs->offCY = offy;
-		kargs->ldc.vector = incy;	// Will be using this as incy
+		kargs->ldc.Vector = incy;	// Will be using this as incy
 
 		#ifdef DEBUG_SWAP
 		printf("Calling makeSolutionSeq from DoSwap: SWAP\n");

--- a/src/library/blas/xsymv.c
+++ b/src/library/blas/xsymv.c
@@ -84,10 +84,10 @@ doSymv(
     kargs->lda.matrix = lda;
     kargs->B = x;
     kargs->offBX = offx;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = y;
     kargs->offCY = offy;
-    kargs->ldc.vector = incy;
+    kargs->ldc.Vector = incy;
 
     #ifndef USE_SYMV
 

--- a/src/library/blas/xsyr.c
+++ b/src/library/blas/xsyr.c
@@ -104,7 +104,7 @@ doSyr(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = X;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->offBX = offx;
     kargs->offa = offa;
 	kargs->offA = offa;

--- a/src/library/blas/xsyr2.c
+++ b/src/library/blas/xsyr2.c
@@ -109,10 +109,10 @@ doSyr2(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = X;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->offBX = offx;
 	kargs->C = Y;
-	kargs->ldc.vector = incy;
+	kargs->ldc.Vector = incy;
 	kargs->offCY = offy;
     kargs->offa = offa;
     kargs->offA = offa;

--- a/src/library/blas/xtbmv.c
+++ b/src/library/blas/xtbmv.c
@@ -143,9 +143,9 @@ doTbmv(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = y;       // Now it becomes x = A * y
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = x;
-    kargs->ldc.vector = incx;
+    kargs->ldc.Vector = incx;
     kargs->offBX = 0;           // Not used by assignKargs(); Just for clarity
     kargs->offCY = offx;
 	kargs->offa = offa;

--- a/src/library/blas/xtbsv.c
+++ b/src/library/blas/xtbsv.c
@@ -153,15 +153,15 @@ if (err == CL_SUCCESS)
                 gbmv->args.offA += kargs->offA;
                 gbmv->args.offa = gbmv->args.offA;
 
-                if(kargs->ldb.vector < 0)
+                if(kargs->ldb.Vector < 0)
                 {
-                    gbmv->args.offBX = kargs->offBX + ((i-1) * TARGET_ROWS) * abs(kargs->ldb.vector);
-                    gbmv->args.offCY = kargs->offBX + ((i * TARGET_ROWS) ) * abs(kargs->ldb.vector);
+                    gbmv->args.offBX = kargs->offBX + ((i-1) * TARGET_ROWS) * abs(kargs->ldb.Vector);
+                    gbmv->args.offCY = kargs->offBX + ((i * TARGET_ROWS) ) * abs(kargs->ldb.Vector);
                 }
                 else
                 {
-                    gbmv->args.offBX = kargs->offBX + (trtri->args.startRow) * kargs->ldb.vector;
-                    gbmv->args.offCY = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.vector;
+                    gbmv->args.offBX = kargs->offBX + (trtri->args.startRow) * kargs->ldb.Vector;
+                    gbmv->args.offCY = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.Vector;
                 }
 
             } else {
@@ -176,15 +176,15 @@ if (err == CL_SUCCESS)
                 gbmv->args.offA -= gbmv->args.KL;
                 gbmv->args.offA += kargs->offA;
                 gbmv->args.offa = gbmv->args.offA;
-                if(kargs->ldb.vector < 0)
+                if(kargs->ldb.Vector < 0)
                 {
-                    gbmv->args.offBX = kargs->offBX + (kargs->N - gbmv->args.startRow) * abs(kargs->ldb.vector);
-                    gbmv->args.offCY = kargs->offBX + (kargs->N - (gbmv->args.startRow + gbmv->args.M) ) * abs(kargs->ldb.vector);
+                    gbmv->args.offBX = kargs->offBX + (kargs->N - gbmv->args.startRow) * abs(kargs->ldb.Vector);
+                    gbmv->args.offCY = kargs->offBX + (kargs->N - (gbmv->args.startRow + gbmv->args.M) ) * abs(kargs->ldb.Vector);
                 }
                 else
                 {
-                    gbmv->args.offBX = kargs->offBX + (trtri->args.startRow) * kargs->ldb.vector;
-                    gbmv->args.offCY = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.vector;
+                    gbmv->args.offBX = kargs->offBX + (trtri->args.startRow) * kargs->ldb.Vector;
+                    gbmv->args.offCY = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.Vector;
                 }
 
             }
@@ -388,15 +388,15 @@ offa = r * lda + col - (r - k);
                 gbmv->args.offA += kargs->offA;
                 gbmv->args.offa = gbmv->args.offA;
 
-                if(kargs->ldb.vector < 0)
+                if(kargs->ldb.Vector < 0)
                 {
-                    gbmv->args.offBX = kargs->offBX + (kargs->N - (gbmv->args.endRow)) * abs(kargs->ldb.vector);
-                    gbmv->args.offCY = kargs->offBX + (kargs->N - (gbmv->args.endRow + gbmv->args.N) ) * abs(kargs->ldb.vector);
+                    gbmv->args.offBX = kargs->offBX + (kargs->N - (gbmv->args.endRow)) * abs(kargs->ldb.Vector);
+                    gbmv->args.offCY = kargs->offBX + (kargs->N - (gbmv->args.endRow + gbmv->args.N) ) * abs(kargs->ldb.Vector);
                 }
                 else
                 {
-                    gbmv->args.offBX = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.vector;
-                    gbmv->args.offCY = kargs->offBX + (gbmv->args.endRow) * kargs->ldb.vector;
+                    gbmv->args.offBX = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.Vector;
+                    gbmv->args.offCY = kargs->offBX + (gbmv->args.endRow) * kargs->ldb.Vector;
                 }
 
 
@@ -416,15 +416,15 @@ offa = r * lda + col - (r - k);
                 gbmv->args.offA -= gbmv->args.KL;
                 gbmv->args.offA += kargs->offA;
                 gbmv->args.offa = gbmv->args.offA;
-                if(kargs->ldb.vector < 0)
+                if(kargs->ldb.Vector < 0)
                 {
-                    gbmv->args.offBX = kargs->offBX + (kargs->N - gbmv->args.endRow) * abs(kargs->ldb.vector);
-                    gbmv->args.offCY = kargs->offBX + (kargs->N - (gbmv->args.startRow) ) * abs(kargs->ldb.vector);
+                    gbmv->args.offBX = kargs->offBX + (kargs->N - gbmv->args.endRow) * abs(kargs->ldb.Vector);
+                    gbmv->args.offCY = kargs->offBX + (kargs->N - (gbmv->args.startRow) ) * abs(kargs->ldb.Vector);
                 }
                 else
                 {
-                    gbmv->args.offBX = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.vector;
-                    gbmv->args.offCY = kargs->offBX + (gbmv->args.startRow - gbmv->args.N) * kargs->ldb.vector;
+                    gbmv->args.offBX = kargs->offBX + (gbmv->args.startRow) * kargs->ldb.Vector;
+                    gbmv->args.offCY = kargs->offBX + (gbmv->args.startRow - gbmv->args.N) * kargs->ldb.Vector;
                 }
 
             }
@@ -626,13 +626,13 @@ doTbsv(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = x;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->offBX = offx;
 	kargs->offa = offa;
 	kargs->offA = offa;
     kargs->C = x;
     kargs->offCY = offx;
-    kargs->ldc.vector = incx;
+    kargs->ldc.Vector = incx;
     kargs->startRow = 0;
 
     if(trans == clblasNoTrans)

--- a/src/library/blas/xtrmv.c
+++ b/src/library/blas/xtrmv.c
@@ -132,9 +132,9 @@ doTrmv(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = x;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->C = y;
-    kargs->ldc.vector = incx;
+    kargs->ldc.Vector = incx;
     kargs->offBX = offx;
     kargs->offCY = 0; // Not used by assignKargs(); Just for clarity
 	kargs->offa = offa;

--- a/src/library/blas/xtrsv.c
+++ b/src/library/blas/xtrsv.c
@@ -406,7 +406,7 @@ doTrsv(
     kargs->A = A;
     kargs->lda.matrix = lda;
     kargs->B = x;
-    kargs->ldb.vector = incx;
+    kargs->ldb.Vector = incx;
     kargs->offBX = offx;
 	kargs->offa = offa;
 	kargs->offA = offa;


### PR DESCRIPTION
Powerpc64 P8 and upper systems include altivec vector capabilities. Compilation requires to disable the bool defintion not properly translated as well as the mismatch with the vector name now being a reserved keyword.