### PR TITLE
fix documentation error for TRMM #270

### DIFF
--- a/group__TRMM.html
+++ b/group__TRMM.html
@@ -250,8 +250,8 @@ Functions</h2></td></tr>
     <tr><td class="paramdir">[in]</td><td class="paramname">M</td><td>Number of rows in matrix <b>B</b>. </td></tr>
     <tr><td class="paramdir">[in]</td><td class="paramname">N</td><td>Number of columns in matrix <b>B</b>. </td></tr>
     <tr><td class="paramdir">[in]</td><td class="paramname">alpha</td><td>The factor of matrix <b>A</b>. </td></tr>
-    <tr><td class="paramdir">[in]</td><td class="paramname">offA</td><td>Offset of the first element of the matrix <b>A</b> in the buffer object. Counted in elements. </td></tr>
     <tr><td class="paramdir">[in]</td><td class="paramname">A</td><td>Buffer object storing matrix <b>A</b>. </td></tr>
+    <tr><td class="paramdir">[in]</td><td class="paramname">offA</td><td>Offset of the first element of the matrix <b>A</b> in the buffer object. Counted in elements. </td></tr>
     <tr><td class="paramdir">[in]</td><td class="paramname">lda</td><td>Leading dimension of matrix <b>A</b>. For detailed description, see <a class="el" href="group__TRMM.html#ga62d4746230cfe35d46130d58d6d66918" title="Multiplying a matrix by a triangular matrix with float elements. Extended version. ">clblasStrmm()</a>. </td></tr>
     <tr><td class="paramdir">[out]</td><td class="paramname">B</td><td>Buffer object storing matrix <b>B</b>. </td></tr>
     <tr><td class="paramdir">[in]</td><td class="paramname">offB</td><td>Offset of the first element of the matrix <b>B</b> in the buffer object. Counted in elements. </td></tr>


### PR DESCRIPTION
'offa' and 'A' was swapped in the description

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/275)
<!-- Reviewable:end -->
