### PR TITLE
add missing dependency to pthread (using rwlock functions)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,7 @@ endif( )
 # add the math library for Linux
 if( UNIX ) 
     set(MATH_LIBRARY "m")
+    set(THREAD_LIBRARY "pthread")
 endif()
 
 # set the path to specific OpenCL compiler

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -886,7 +886,7 @@ endif()
 set_target_properties(clBLAS PROPERTIES VERSION ${clBLAS_VERSION})
 set_target_properties(clBLAS PROPERTIES SOVERSION ${clBLAS_SOVERSION})
 set_target_properties( clBLAS PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging" )
-target_link_libraries(clBLAS ${OPENCL_LIBRARIES} ${MATH_LIBRARY})
+target_link_libraries(clBLAS ${OPENCL_LIBRARIES} ${MATH_LIBRARY} ${THREAD_LIBRARY})
 
 # CPack configuration; include the executable into the package
 install( TARGETS clBLAS


### PR DESCRIPTION
Experiencing a build failure which is probably due to implicit dependency to -lpthread which might be satisfied by some OpenCL implementations. Explicitly specifying the dependency to pthread (used in common/rwlock.c solves the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/278)
<!-- Reviewable:end -->
