### PR TITLE
Disable clang error on narrowing conversions.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -319,6 +319,8 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     if(TARGET_PLATFORM EQUAL 32)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-builtin")
     endif()
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")
 elseif( MSVC )
 	# CMake sets huge stack frames for windows, for whatever reason.  We go with compiler default.
 	string( REGEX REPLACE "/STACK:[0-9]+" "" CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS}" )


### PR DESCRIPTION
clang with ```-std=c++11``` fails to compile the project because there are narrowing conversions in ```src/library/blas/xtrsm.cc``` and a bunch of other files. The problem is reproducible for me if instead of

    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-narrowing")

I set

    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

Disabling the error seems like the easiest solution. Another alternative is to add explicit casts, but it touched multiple places in the code so I figured that this is the safer path.

Also, having an explicit section with compile options for clang may save some confusion - I spent quite a bit of time wondering why my CXXFLAGS are not respected until I realized that clang is not considered a GNUCXX compiler so the first ```if``` does not apply to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clmathlibraries/clblas/281)
<!-- Reviewable:end -->
