### PR TITLE
fix ixamax and syr2/her2

### DIFF
--- a/src/library/blas/gens/clTemplates/her2.cl
+++ b/src/library/blas/gens/clTemplates/her2.cl
@@ -138,8 +138,8 @@ __kernel void %PREFIXher2_CL_kernel( __global const %TYPE* _A, __global const %T
 				%CONJUGATE(1, res1);
 			#endif
             %MUL( res5, alpha, res1 );
-            res1 = Y[c * incx];
-            res3 = Y[r * incx];
+            res1 = Y[c * incy];
+            res3 = Y[r * incy];
             #ifndef HER2_ROWMAJOR
 				%CONJUGATE(1, res1);
             #endif
@@ -461,8 +461,8 @@ __kernel void %PREFIXher2_CU_kernel( __global const %TYPE* _A, __global const %T
 				%CONJUGATE(1, res1);
 			#endif
             %MUL( res5, alpha, res1 );
-            res1 = Y[c * incx];
-            res3 = Y[r * incx];
+            res1 = Y[c * incy];
+            res3 = Y[r * incy];
             #ifndef HER2_ROWMAJOR
 				%CONJUGATE(1, res1);
             #endif

--- a/src/library/blas/gens/clTemplates/syr2.cl
+++ b/src/library/blas/gens/clTemplates/syr2.cl
@@ -128,9 +128,9 @@ __kernel void %PREFIXsyr2_CL_kernel( __global const %TYPE* _A, __global const %T
 
             %TYPE res1, res2;
             res1 = alpha * X[c * incx];
-			res2 = alpha * X[r * incx];
-            res1 = res1 * Y[r * incx];
-			res2 = res2 * Y[c * incx];
+            res2 = alpha * X[r * incx];
+            res1 = res1 * Y[r * incy];
+            res2 = res2 * Y[c * incy];
 
 			A[r + c * lda] += (res1 + res2);
         }

--- a/src/library/blas/gens/clTemplates/syr2_her2.cl
+++ b/src/library/blas/gens/clTemplates/syr2_her2.cl
@@ -148,8 +148,8 @@ __kernel void %PREFIXsyr2_her2_CL_kernel( __global %TYPE* _A, __global const %TY
 				#endif
 			#endif
             %MUL( res5, alpha, res1 );
-            res1 = Y[c * incx];
-            res3 = Y[r * incx];
+            res1 = Y[c * incy];
+            res3 = Y[r * incy];
             #ifdef HER2_ONLY
 				#ifndef HER2_ROWMAJOR
 					%CONJUGATE(1, res1);
@@ -514,8 +514,8 @@ __kernel void %PREFIXsyr2_her2_CU_kernel( __global %TYPE* _A, __global const %TY
 				#endif
 			#endif
             %MUL( res5, alpha, res1 );
-            res1 = Y[c * incx];
-            res3 = Y[r * incx];
+            res1 = Y[c * incy];
+            res3 = Y[r * incy];
             #ifdef HER2_ONLY
 				#ifndef HER2_ROWMAJOR
 					%CONJUGATE(1, res1);

--- a/src/library/blas/gens/iamax.cpp
+++ b/src/library/blas/gens/iamax.cpp
@@ -108,7 +108,7 @@ selectVectorization(
 	KernelExtraFlags kflags = KEXTRA_NO_FLAGS;
 	CLBlasKargs *kargs  = (CLBlasKargs *)args;
 
-    if( (((kargs->offa) % vlen) != 0))
+    if( (((kargs->offb) % vlen) != 0))
     {
         kflags = KEXTRA_NO_COPY_VEC_A;
     }


### PR DESCRIPTION
Two bug fixes:
1) ixamax crashes if x offset is not a multiple of vector size. Caused by checking offa, when it should check offb, to determine whether to use vload.
2) syr2/her2 get wrong result when incx != incy. Caused by Y using incx instead of incy.