### PR TITLE
Detect CBLAS when building the client

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -267,10 +267,7 @@ if( BUILD_TEST )
 endif( )
 
 if( BUILD_CLIENT )
-    if( NETLIB_FOUND )
-    else( )
-        message( WARNING "Not find Netlib; BUILD_CLIENT needs the Netlib CBLAS library" )
-    endif()
+    find_package( Netlib COMPONENTS BLAS REQUIRED )
 endif()
 
 


### PR DESCRIPTION
Builds with `BUILD_CLIENT=ON` and `BUILD_TESTS=OFF` fail because CBLAS detection is only performed when `BUILD_TESTS` is set to ON. This patch addresses this issue by also detecting CBLAS when `BUILD_CLIENT` is set to ON.