### PR TITLE
Fixing internal library cl_event leaks

### DIFF
--- a/src/library/blas/generic/common.c
+++ b/src/library/blas/generic/common.c
@@ -537,11 +537,13 @@ setupBuildOpts(
     identifyDevice(&target);
     opts[0] = '\0';
 
-#if !defined NDEBUG
-    // Nvidia runtime does not appear to support the -g flag, at least in their OpenCL v1.1 runtime
-    if( target.ident.vendor != VENDOR_NVIDIA )
-        addBuildOpt( opts, BUILD_OPTS_MAXLEN, "-g" );
-#endif  /* NDEBUG */
+
+// clBuildProgram is crashing in xTRMM with the '-g' debug flag
+//#if !defined NDEBUG
+//    // Nvidia runtime does not appear to support the -g flag, at least in their OpenCL v1.1 runtime
+//    if( target.ident.vendor != VENDOR_NVIDIA )
+//        addBuildOpt( opts, BUILD_OPTS_MAXLEN, "-g" );
+//#endif  /* NDEBUG */
 
     if (target.ident.vendor == VENDOR_NVIDIA &&
         !strcmp(mempat->name, "2-staged cached global memory based "

--- a/src/library/blas/generic/solution_seq.c
+++ b/src/library/blas/generic/solution_seq.c
@@ -238,7 +238,7 @@ releaseStepImgs(SolutionStep *step)
 {
     int i;
     cl_mem *imgs = step->args.scimage;
-    cl_device_id devID = NULL;;
+    cl_device_id devID = NULL;
 
     for (i = 0; (i < 2) && (imgs[i] != NULL); i++) {
         if (devID == NULL) {

--- a/src/library/blas/ixamax.c
+++ b/src/library/blas/ixamax.c
@@ -43,7 +43,7 @@ doiAmax(
         cl_int err;
 		ListHead seq, seq2;
         clblasStatus retCode = clblasSuccess;
-        cl_event firstiAmaxCall;
+        cl_event firstiAmaxCall = NULL;
         CLBlasKargs redctnArgs;
         ListNode *listNodePtr;
         SolutionStep *step;
@@ -150,6 +150,7 @@ doiAmax(
                     err = executeSolutionSeq(&seq2);
                 }
                 freeSolutionSeq(&seq2);
+                clReleaseEvent(firstiAmaxCall);
             }
 		}
 

--- a/src/library/blas/xasum.c
+++ b/src/library/blas/xasum.c
@@ -43,7 +43,7 @@ doAsum(
         cl_int err;
 		ListHead seq, seq2;
         clblasStatus retCode = clblasSuccess;
-        cl_event firstAsumCall;
+        cl_event firstAsumCall = NULL;
         CLBlasKargs redctnArgs;
         ListNode *listNodePtr;
         SolutionStep *step;
@@ -147,6 +147,7 @@ doAsum(
                     err = executeSolutionSeq(&seq2);
                 }
                 freeSolutionSeq(&seq2);
+                clReleaseEvent(firstAsumCall);
             }
 		}
 

--- a/src/library/blas/xdot.c
+++ b/src/library/blas/xdot.c
@@ -47,7 +47,7 @@ doDot(
         cl_int err;
 		ListHead seq, seq2;
         clblasStatus retCode = clblasSuccess;
-        cl_event firstDotCall;
+        cl_event firstDotCall = NULL;
         CLBlasKargs redctnArgs;
         ListNode *listNodePtr;
         SolutionStep *step;
@@ -140,22 +140,23 @@ doDot(
             err = executeSolutionSeq(&seq);
             if (err == CL_SUCCESS)
             {
-            listNodePtr = listNodeFirst(&seq);        // Get the node
-            step = container_of(listNodePtr, node, SolutionStep);
+                listNodePtr = listNodeFirst(&seq);        // Get the node
+                step = container_of(listNodePtr, node, SolutionStep);
 
-                redctnArgs.N = step->pgran.numWGSpawned[0];     // 1D block was used
+                    redctnArgs.N = step->pgran.numWGSpawned[0];     // 1D block was used
 
                 listInitHead(&seq2);
-            err = makeSolutionSeq(CLBLAS_REDUCTION_EPILOGUE, &redctnArgs, numCommandQueues, commandQueues,
-                           1, &firstDotCall, events, &seq2);
+                err = makeSolutionSeq(CLBLAS_REDUCTION_EPILOGUE, &redctnArgs, numCommandQueues, commandQueues,
+                               1, &firstDotCall, events, &seq2);
 
-            if (err == CL_SUCCESS)
-            {
-                    err = executeSolutionSeq(&seq2);
-            }
+                if (err == CL_SUCCESS)
+                {
+                        err = executeSolutionSeq(&seq2);
+                }
                 freeSolutionSeq(&seq2);
-		}
-		}
+                clReleaseEvent(firstDotCall);
+            }
+        }
 
 		freeSolutionSeq(&seq);
 		return (clblasStatus)err;

--- a/src/library/blas/xhemv.c
+++ b/src/library/blas/xhemv.c
@@ -45,7 +45,7 @@ doHemv(
 {
     cl_int err;
     ListHead seq1, seq2;
-	cl_event first_event;
+	cl_event first_event = NULL;
     clblasStatus retCode = clblasSuccess;
 
     if (!clblasInitialized) {
@@ -110,7 +110,8 @@ doHemv(
 				err = executeSolutionSeq(&seq2);
 			}
 			freeSolutionSeq(&seq2);
-		}
+            clReleaseEvent(first_event);
+        }
     }
 
     freeSolutionSeq(&seq1);

--- a/src/library/blas/xher2k.c
+++ b/src/library/blas/xher2k.c
@@ -53,7 +53,7 @@ doHer2k(
     clblasStatus err;
     clblasUplo fUplo;
     clblasTranspose fTransA;
-    cl_event firstHerkCall;
+    cl_event firstHerkCall = NULL;
     clblasStatus retCode = clblasSuccess;
 
     if (!clblasInitialized) {
@@ -146,6 +146,7 @@ doHer2k(
         }
 
         err = executeGEMM(kargs,  numCommandQueues, commandQueues, 1, &firstHerkCall, events);
+        clReleaseEvent(firstHerkCall);
     }
 
     return (clblasStatus)err;

--- a/src/library/blas/xhpmv.c
+++ b/src/library/blas/xhpmv.c
@@ -44,7 +44,7 @@ doHpmv(
 {
     cl_int err;
     ListHead seq1, seq2;
-	cl_event first_event;
+	cl_event first_event = NULL;
     clblasStatus retCode = clblasSuccess;
 
     if (!clblasInitialized) {
@@ -111,7 +111,8 @@ doHpmv(
 				err = executeSolutionSeq(&seq2);
 			}
 			freeSolutionSeq(&seq2);
-		}
+            clReleaseEvent(first_event);
+        }
     }
 
     freeSolutionSeq(&seq1);

--- a/src/library/blas/xnrm2.c
+++ b/src/library/blas/xnrm2.c
@@ -35,7 +35,7 @@ doNrm2_hypot(CLBlasKargs *kargs,
 {
     cl_int err;
 	ListHead seq, seq2;
-    cl_event firstNrmCall;
+    cl_event firstNrmCall = NULL;
     CLBlasKargs redctnArgs;
     ListNode *listNodePtr;
     SolutionStep *step;
@@ -76,6 +76,7 @@ doNrm2_hypot(CLBlasKargs *kargs,
                 err = executeSolutionSeq(&seq2);
             }
             freeSolutionSeq(&seq2);
+            clReleaseEvent(firstNrmCall);
         }
     }
 
@@ -93,7 +94,7 @@ doNrm2_ssq(CLBlasKargs *kargs,
 {
     cl_int err;
 	ListHead seq, seq2;
-    cl_event firstNrmCall;
+    cl_event firstNrmCall = NULL;
     CLBlasKargs redctnArgs;
     ListNode *listNodePtr;
     SolutionStep *step;
@@ -134,6 +135,7 @@ doNrm2_ssq(CLBlasKargs *kargs,
                 err = executeSolutionSeq(&seq2);
             }
             freeSolutionSeq(&seq2);
+            clReleaseEvent(firstNrmCall);
         }
     }
 

--- a/src/library/blas/xspmv.c
+++ b/src/library/blas/xspmv.c
@@ -44,7 +44,7 @@ doSpmv(
 {
     cl_int err;
     ListHead seq1, seq2;
-	cl_event first_event;
+	cl_event first_event = NULL;
     clblasStatus retCode = clblasSuccess;
 
     if (!clblasInitialized) {
@@ -113,7 +113,8 @@ doSpmv(
 				err = executeSolutionSeq(&seq2);
 			}
 			freeSolutionSeq(&seq2);
-		}
+            clReleaseEvent(first_event);
+        }
     }
 
     freeSolutionSeq(&seq1);

--- a/src/library/blas/xtrsv.c
+++ b/src/library/blas/xtrsv.c
@@ -199,8 +199,8 @@ orchestrateTransposeTRSV(CLBlasKargs *kargs, ListHead *trtriSeq, ListHead *gemvS
 	//
 	// Allocate Event Arrays to order the orchestration
 	//
-	triangleEventArray = malloc(nLoops*sizeof(cl_event));
-	rectangleEventArray = malloc(nLoops*sizeof(cl_event));
+	triangleEventArray = calloc(nLoops, sizeof(cl_event));
+	rectangleEventArray = calloc(nLoops, sizeof(cl_event));
 	if ((triangleEventArray == NULL) || (rectangleEventArray == NULL))
 	{
 		if (triangleEventArray)
@@ -289,8 +289,18 @@ orchestrateTransposeTRSV(CLBlasKargs *kargs, ListHead *trtriSeq, ListHead *gemvS
 		}
 	}
 
-	free(triangleEventArray);
-	free(rectangleEventArray);
+    // Clean up internal events
+    for (i = 0; i < nLoops; i++)
+    {
+        clReleaseEvent(triangleEventArray[i]);
+        triangleEventArray[i] = NULL;
+        clReleaseEvent(rectangleEventArray[i]);
+        rectangleEventArray[i] = NULL;
+    }
+
+    free(triangleEventArray);
+    free(rectangleEventArray);
+
 	return err;
 }
 


### PR DESCRIPTION
Many L2 & L1 routines, which used multiple kernels to compute result
leaked internal cl_events.

Removed '-g' clBuildProgram option from library debug builds.  This
flag causes an internal compiler error for debug builds in xTRMM.  The
flag is not very useful and has caused too many problems.