### PR TITLE
Fix call to setDeviceType in test-performance.cpp

### DIFF
--- a/src/tests/performance/test-performance.cpp
+++ b/src/tests/performance/test-performance.cpp
@@ -1278,7 +1278,7 @@ main(int argc, char *argv[])
         }
 
         if (params.optFlags & SET_DEVICE_TYPE) {
-            if (!base->setDeviceType(&params.devType, params.devName)) {
+            if (!base->setDeviceType(params)) {
                 ::std::cerr << "Fatal error, OpenCL or clblas "
                         "initialization failed! Leaving the test." <<
                         ::std::endl;


### PR DESCRIPTION
setDeviceType only takes one argument: params. This was causing build errors.