### PR TITLE
Use .s[0] instead of .x in example_ctrsm.c

### DIFF
--- a/src/samples/example_ctrsm.c
+++ b/src/samples/example_ctrsm.c
@@ -71,7 +71,7 @@ printResult(const char* str)
     nrows = (sizeof(result) / sizeof(FloatComplex)) / ldb;
     for (i = 0; i < nrows; i++) {
         for (j = 0; j < ldb; j++) {
-            printf("%.5f ", result[i * ldb + j].x);
+            printf("%.5f ", result[i * ldb + j].s[0]);
         }
         printf("\n");
     }


### PR DESCRIPTION
.s is more portable, and .x does not work with -std=c99 which
does not have anonymous structs.

Fix #307.