### PR TITLE
Use CL_DEVICE_TYPE_ALL for all samples

### DIFF
--- a/src/samples/example_chbmv.c
+++ b/src/samples/example_chbmv.c
@@ -91,7 +91,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_cher.c
+++ b/src/samples/example_cher.c
@@ -84,7 +84,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_cher2k.c
+++ b/src/samples/example_cher2k.c
@@ -100,7 +100,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_chpmv.c
+++ b/src/samples/example_chpmv.c
@@ -88,7 +88,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_chpr.c
+++ b/src/samples/example_chpr.c
@@ -90,7 +90,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_csscal.c
+++ b/src/samples/example_csscal.c
@@ -73,7 +73,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ctrsm.c
+++ b/src/samples/example_ctrsm.c
@@ -71,7 +71,7 @@ printResult(const char* str)
     nrows = (sizeof(result) / sizeof(FloatComplex)) / ldb;
     for (i = 0; i < nrows; i++) {
         for (j = 0; j < ldb; j++) {
-            printf("%.5f ", result[i * ldb + j].x);
+            printf("%.5f ", result[i * ldb + j].s[0]);
         }
         printf("\n");
     }

--- a/src/samples/example_ctrsm.c
+++ b/src/samples/example_ctrsm.c
@@ -81,7 +81,7 @@ int
 main(void)
 {
     cl_int err;
-    cl_platform_id platform[] = { 0, 0 };
+    cl_platform_id platform = 0;
     cl_device_id device = 0;
     cl_context_properties props[3] = { CL_CONTEXT_PLATFORM, 0, 0 };
     cl_context ctx = 0;
@@ -97,7 +97,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform[0], CL_DEVICE_TYPE_CPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_dtrmv.c
+++ b/src/samples/example_dtrmv.c
@@ -95,7 +95,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_isamax.c
+++ b/src/samples/example_isamax.c
@@ -63,7 +63,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sasum.c
+++ b/src/samples/example_sasum.c
@@ -61,7 +61,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_saxpy.c
+++ b/src/samples/example_saxpy.c
@@ -86,7 +86,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_scopy.c
+++ b/src/samples/example_scopy.c
@@ -90,7 +90,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sdot.c
+++ b/src/samples/example_sdot.c
@@ -73,7 +73,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sgbmv.c
+++ b/src/samples/example_sgbmv.c
@@ -97,7 +97,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sgemm.c
+++ b/src/samples/example_sgemm.c
@@ -108,7 +108,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sgemv.c
+++ b/src/samples/example_sgemv.c
@@ -101,7 +101,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sger.c
+++ b/src/samples/example_sger.c
@@ -96,7 +96,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_snrm2.c
+++ b/src/samples/example_snrm2.c
@@ -61,7 +61,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_srot.c
+++ b/src/samples/example_srot.c
@@ -83,13 +83,13 @@ main(void)
     /* Setup OpenCL environment. */
     err = clGetPlatformIDs(1, &platform, NULL);
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetPlatformIDs() failed with %d\n", err );
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
 
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );

--- a/src/samples/example_srotg.c
+++ b/src/samples/example_srotg.c
@@ -59,7 +59,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_srotm.c
+++ b/src/samples/example_srotm.c
@@ -97,7 +97,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_srotmg.c
+++ b/src/samples/example_srotmg.c
@@ -68,7 +68,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssbmv.c
+++ b/src/samples/example_ssbmv.c
@@ -93,7 +93,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sscal.c
+++ b/src/samples/example_sscal.c
@@ -73,7 +73,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sspmv.c
+++ b/src/samples/example_sspmv.c
@@ -90,7 +90,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sspr.c
+++ b/src/samples/example_sspr.c
@@ -90,7 +90,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sspr2.c
+++ b/src/samples/example_sspr2.c
@@ -99,7 +99,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_sswap.c
+++ b/src/samples/example_sswap.c
@@ -91,7 +91,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssymm.c
+++ b/src/samples/example_ssymm.c
@@ -98,7 +98,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssymv.c
+++ b/src/samples/example_ssymv.c
@@ -102,7 +102,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssyr.c
+++ b/src/samples/example_ssyr.c
@@ -84,7 +84,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssyr2.c
+++ b/src/samples/example_ssyr2.c
@@ -94,7 +94,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssyr2k.c
+++ b/src/samples/example_ssyr2k.c
@@ -108,7 +108,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_ssyrk.c
+++ b/src/samples/example_ssyrk.c
@@ -98,7 +98,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_stbmv.c
+++ b/src/samples/example_stbmv.c
@@ -80,7 +80,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_stbsv.c
+++ b/src/samples/example_stbsv.c
@@ -83,7 +83,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_stpmv.c
+++ b/src/samples/example_stpmv.c
@@ -78,7 +78,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_stpsv.c
+++ b/src/samples/example_stpsv.c
@@ -82,7 +82,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_strmm.c
+++ b/src/samples/example_strmm.c
@@ -96,7 +96,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_strmv.c
+++ b/src/samples/example_strmv.c
@@ -79,7 +79,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_strsm.c
+++ b/src/samples/example_strsm.c
@@ -97,7 +97,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_strsm.cpp
+++ b/src/samples/example_strsm.cpp
@@ -80,8 +80,7 @@ int
 main(void)
 {
     cl_int err;
-    // Increase platforms array for system needs; 2 covers most situations
-    cl_platform_id platforms[] = { 0,0 };
+    cl_platform_id platform = 0;
     cl_device_id device = 0;
     cl_context_properties props[3] = { CL_CONTEXT_PLATFORM, 0, 0 };
     cl_context ctx = 0;
@@ -95,23 +94,19 @@ main(void)
     makeScaledIdentity( result, M, N, 0.0f);
 
     /* Setup OpenCL environment. */
-    err = clGetPlatformIDs( sizeof( platforms )/ sizeof( cl_platform_id ), &platforms[0], NULL);
+    err = clGetPlatformIDs( 1, &platform, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetPlatformIDs() failed with %d\n", err );
         return 1;
     }
 
-    // Change this statement to pick the desired platform under test
-    cl_platform_id test_platform = platforms[1];
-
-    //!!!  Change device type to validate; works on GPU, faults on CPU
-    err = clGetDeviceIDs(test_platform, CL_DEVICE_TYPE_CPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;
     }
 
-    props[1] = (cl_context_properties)test_platform;
+    props[1] = (cl_context_properties)platform;
     ctx = clCreateContext(props, 1, &device, NULL, NULL, &err);
     if (err != CL_SUCCESS) {
         printf( "clCreateContext() failed with %d\n", err );

--- a/src/samples/example_strsv.c
+++ b/src/samples/example_strsv.c
@@ -80,7 +80,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_zher2.c
+++ b/src/samples/example_zher2.c
@@ -93,7 +93,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;

--- a/src/samples/example_zhpr2.c
+++ b/src/samples/example_zhpr2.c
@@ -99,7 +99,7 @@ main(void)
         return 1;
     }
 
-    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_GPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;


### PR DESCRIPTION
This increases the chance that they will just work for most users.
    
Previously there was a mixture of CPU and GPU, which only works
if users have both CPU and GPU OpenCL devices.

Depends on: https://github.com/clMathLibraries/clBLAS/pull/309 otherwise samples won't even build.