### PR TITLE
Some fixes in tilemul tester

### DIFF
--- a/src/library/blas/gens/blas_kgen.h
+++ b/src/library/blas/gens/blas_kgen.h
@@ -116,7 +116,7 @@ typedef enum TileMulFlags {
                                           itself */
 
     /**
-     * Deprecated. Use the repsective mode being a part of FetchAddr mode.
+     * Deprecated. Use the respective mode being a part of FetchAddr mode.
      * He is left just for backward compatibility to don't break the working
      * code and will be removed soon
      */
@@ -142,17 +142,13 @@ typedef enum TileMulFlags {
                             TILEMUL_GLOBAL_CYCLIC_K,
     /** Use bwidth0 stride */
     TILEMUL_BW_STRIDE = 0x4000,
-    /** Optimize coordinates calculations by using vectors
-     *  and pointer increments */
-    // Deprecated
-    TILEMUL_OPTIMIZE_VEC_COORDS = 0x8000,
     /** Do not increment K*/
-    TILEMUL_NOT_INC_K = 0x10000,
+    TILEMUL_NOT_INC_K = 0x8000,
     /**
      * Use variants with explicit vectorization. Useful on platforms with
      * true SIMD.
      */
-    TILEMUL_FORCE_VECTORIZATION = 0x20000
+    TILEMUL_FORCE_VECTORIZATION = 0x10000
 } TileMulFlags;
 
 
@@ -253,10 +249,6 @@ typedef struct KernelVarNames {
     const char *lda;        /**< Leading dimension of matrix A */
     const char *ldb;        /**< Leading dimension of matrix B */
     const char *ldc;        /**< Leading dimension of matrix C, in vectors */
-    const char *vectCoordA; /**< Vector containing indexes of tile a elements
-                                 in matrix A */
-    const char *vectCoordB; /**< Vector containing indexes of tile b elements
-                                 in matrix B*/
     const char *startM;
     const char *startN;
     const char *startK;

--- a/src/library/blas/gens/blas_kgen.h
+++ b/src/library/blas/gens/blas_kgen.h
@@ -140,24 +140,19 @@ typedef enum TileMulFlags {
     TILEMUL_GLOBAL_CYCLIC = TILEMUL_GLOBAL_CYCLIC_A |
                             TILEMUL_GLOBAL_CYCLIC_B |
                             TILEMUL_GLOBAL_CYCLIC_K,
-    // Deprecated
-    TILEMUL_SKEWS = TILEMUL_SKEW_A | TILEMUL_SKEW_B | TILEMUL_SKEW_K,
-    /** Optimize coordinates calculations by storing coordinates values */
-    // Deprecated
-    TILEMUL_OPTIMIZE_COORD_CALC = 0x4000,
     /** Use bwidth0 stride */
-    TILEMUL_BW_STRIDE = 0x8000,
+    TILEMUL_BW_STRIDE = 0x4000,
     /** Optimize coordinates calculations by using vectors
      *  and pointer increments */
     // Deprecated
-    TILEMUL_OPTIMIZE_VEC_COORDS = 0x10000,
+    TILEMUL_OPTIMIZE_VEC_COORDS = 0x8000,
     /** Do not increment K*/
-    TILEMUL_NOT_INC_K = 0x20000,
+    TILEMUL_NOT_INC_K = 0x10000,
     /**
      * Use variants with explicit vectorization. Useful on platforms with
      * true SIMD.
      */
-    TILEMUL_FORCE_VECTORIZATION = 0x40000
+    TILEMUL_FORCE_VECTORIZATION = 0x20000
 } TileMulFlags;
 
 

--- a/src/library/blas/gens/gemm.c
+++ b/src/library/blas/gens/gemm.c
@@ -746,8 +746,6 @@ subgGen(
     vnames->alpha = "alpha";
     vnames->beta = "beta";
 
-    vnames->vectCoordA = "vca";
-    vnames->vectCoordB = "vcb";
     vnames->k = exprK.buf;
 
     subgroupsA = (unsigned int)(gset.subdims[0].y/gset.subdims[1].y);

--- a/src/library/blas/gens/gemv.c
+++ b/src/library/blas/gens/gemv.c
@@ -297,7 +297,6 @@ generator(
         kgenAddBlankLine(ctx);
     }
 
-    mulOpts.flags |= TILEMUL_OPTIMIZE_COORD_CALC;
     if (tailM) {
         mulOpts.flags |= TILEMUL_GLOBAL_CYCLIC_A;
     }

--- a/src/library/blas/gens/symv.c
+++ b/src/library/blas/gens/symv.c
@@ -477,7 +477,6 @@ generator(
         kgenAddBlankLine(ctx);
     }
 
-    mulOpts.flags |= TILEMUL_OPTIMIZE_COORD_CALC;
     if (tailM) {
         vnames->sizeM = "N";
     }


### PR DESCRIPTION
t_tilemul debugging tool fails with division by zero in current development branch. With this changes it works at least with global memory matrices (default option). Some deprecated unused options of tilemul generator were also removed.
test-short passed on my machine (Tonga, AMDGPU-PRO 17.10)