### PR TITLE
fix build issue when include clBLAS as a cmake subproject

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ option( BUILD_PERFORMANCE "Copy the performance scripts that can measure and gra
 option( BUILD_SAMPLE "Build the sample programs" OFF )
 option( BUILD_CLIENT "Build a command line clBLAS client program with a variety of configurable parameters (dependency on Boost)" OFF )
 option( BUILD_KTEST "A command line tool for testing single clBLAS kernel" OFF )
-option( BUILD_SHARED_LIBS "Build shared libraries" ON )
+option( BUILD_SHARED_LIBS "Build shared libraries" OFF )
 
 #enable or disable offline compilation for different devices. Currently only Hawaii, Bonaire, Tahiti have the option.
 #option( OPENCL_OFFLINE_BUILD_HAWAII_KERNEL "Offline compile the OpenCL kernels for Hawaii device" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ option( BUILD_PERFORMANCE "Copy the performance scripts that can measure and gra
 option( BUILD_SAMPLE "Build the sample programs" OFF )
 option( BUILD_CLIENT "Build a command line clBLAS client program with a variety of configurable parameters (dependency on Boost)" OFF )
 option( BUILD_KTEST "A command line tool for testing single clBLAS kernel" OFF )
-option( BUILD_SHARED_LIBS "Build shared libraries" OFF )
+option( BUILD_SHARED_LIBS "Build shared libraries" ON )
 
 #enable or disable offline compilation for different devices. Currently only Hawaii, Bonaire, Tahiti have the option.
 #option( OPENCL_OFFLINE_BUILD_HAWAII_KERNEL "Offline compile the OpenCL kernels for Hawaii device" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,11 +18,11 @@ cmake_minimum_required(VERSION 2.8)
 
 #User toggle-able options that can be changed on the command line with -D
 option( BUILD_RUNTIME "Build the BLAS runtime library" ON )
-option( BUILD_TEST "Build the library testing suite (dependency on google test, Boost, and ACML/NETLIB BLAS)" ON )
+option( BUILD_TEST "Build the library testing suite (dependency on google test, Boost, and ACML/NETLIB BLAS)" OFF )
 option( BUILD_PERFORMANCE "Copy the performance scripts that can measure and graph performance" OFF )
 option( BUILD_SAMPLE "Build the sample programs" OFF )
 option( BUILD_CLIENT "Build a command line clBLAS client program with a variety of configurable parameters (dependency on Boost)" OFF )
-option( BUILD_KTEST "A command line tool for testing single clBLAS kernel" ON )
+option( BUILD_KTEST "A command line tool for testing single clBLAS kernel" OFF )
 option( BUILD_SHARED_LIBS "Build shared libraries" ON )
 
 #enable or disable offline compilation for different devices. Currently only Hawaii, Bonaire, Tahiti have the option.

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -24,14 +24,14 @@ find_package(PythonInterp REQUIRED)
 
 # AutoGemm scripts and out files
 set(AUTOGEMM_SCRIPTS
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/AutoGemm.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/AutoGemmParameters.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/Common.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/Includes.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/KernelOpenCL.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/KernelParameters.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/KernelSelection.py
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/KernelsToPreCompile.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/AutoGemm.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/AutoGemmParameters.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/Common.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/Includes.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/KernelOpenCL.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/KernelParameters.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/KernelSelection.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/KernelsToPreCompile.py
 )
 set(AUTOGEMM_HEADERS
   ${CMAKE_BINARY_DIR}/include/AutoGemmIncludes/AutoGemmClKernels.h
@@ -54,22 +54,22 @@ set(AUTOGEMM_SRC
 )
 
 set(USERGEMM_SRC
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/UserGemmKernelSources/UserGemmClKernels.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/UserGemmKernelSources/UserGemmClKernels.cc
 )
 
 set(USERGEMM_HEADERS
-   ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/UserGemmKernelSources/UserGemmKernelSourceIncludes.h
-   ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/UserGemmKernelSources/UserGemmClKernels.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/UserGemmKernelSources/UserGemmKernelSourceIncludes.h
+   ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/UserGemmKernelSources/UserGemmClKernels.h
 )
 
 set(AUTOGEMM_TEST_SRC
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/AutoGemmTools/TestAutoGemm.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/AutoGemmTools/TestAutoGemm.cpp
 )
 set(AUTOGEMM_PROFILER_SRC
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/AutoGemmTools/ProfileAutoGemm.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/AutoGemmTools/ProfileAutoGemm.cpp
 )
 set(AUTOGEMM_PRECOMPILE_SRC
-  ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/AutoGemmTools/AutoGemmPreCompileKernels.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/AutoGemmTools/AutoGemmPreCompileKernels.cpp
 )
 set( AUTOGEMM_PRECOMPILED_KERNELS
   ${CMAKE_BINARY_DIR}/include/AutoGemmKernelBinaries/AutoGemmKernelBinariesPreCompiled.h
@@ -200,11 +200,11 @@ if ( PRECOMPILE_GEMM_ACTIVE )
 ################################################################################
 # add target for generating pre-compile WhichKernels header
 ################################################################################
-set( AUTOGEMM_PRECOMPILE_HEADER_SRC ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/KernelsToPreCompile.py )
+set( AUTOGEMM_PRECOMPILE_HEADER_SRC ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/KernelsToPreCompile.py )
 set( AUTOGEMM_PRECOMPILE_HEADER_OUT ${CMAKE_BINARY_DIR}/include/AutoGemmIncludes/AutoGemmKernelsToPreCompile.h )
 add_custom_command(
   OUTPUT ${AUTOGEMM_PRECOMPILE_HEADER_OUT}
-  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/KernelsToPreCompile.py ${AGPC_ARGS}
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/KernelsToPreCompile.py ${AGPC_ARGS}
   DEPENDS ${AUTOGEMM_PRECOMPILE_HEADER_SRC}
 )
 
@@ -245,7 +245,7 @@ endif()#endif precompile active
 ################################################################################
 add_custom_command(
   OUTPUT ${AUTOGEMM_HEADERS} ${AUTOGEMM_SRC}
-  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/library/blas/AutoGemm/AutoGemm.py --output-path ${CMAKE_BINARY_DIR}/include --opencl-compiler-version ${OPENCL_VERSION} --architecture ${AUTOGEMM_ARCHITECTURE}
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/blas/AutoGemm/AutoGemm.py --output-path ${CMAKE_BINARY_DIR}/include --opencl-compiler-version ${OPENCL_VERSION} --architecture ${AUTOGEMM_ARCHITECTURE}
   DEPENDS ${AUTOGEMM_SCRIPTS}
 )
 
@@ -692,7 +692,7 @@ endif()
 
 include( ExternalProject )
 ExternalProject_Add( tplgen
-    URL "${CMAKE_SOURCE_DIR}/library/tools/tplgen"
+    URL "${CMAKE_CURRENT_SOURCE_DIR}/tools/tplgen"
     INSTALL_COMMAND ""
 )
 
@@ -701,7 +701,7 @@ if (PRECOMPILE_TRSM_DTRSM OR PRECOMPILE_TRSM_STRSM)
 
 
 ExternalProject_Add( OCLBinaryGenerator
-	URL "${CMAKE_SOURCE_DIR}/library/tools/OCLBinaryGenerator"
+	URL "${CMAKE_CURRENT_SOURCE_DIR}/tools/OCLBinaryGenerator"
 	CMAKE_ARGS -DOPENCL_LIBRARIES=${OPENCL_LIBRARIES} -DOPENCL_INCLUDE_DIRS=${OPENCL_INCLUDE_DIRS}
 	INSTALL_COMMAND ""
 )
@@ -724,7 +724,7 @@ add_custom_target( OCLBinaryGenerator_GEN )
 add_custom_command(TARGET OCLBinaryGenerator_GEN
                    PRE_BUILD
 				   COMMAND ${CMAKE_COMMAND} -DOCLBinaryGeneratorBinaryDir=${OCLBinaryGeneratorBinaryDir} -DSOURCE_DIR=${CMAKE_SOURCE_DIR} -DBINARY_DIR=${CMAKE_BINARY_DIR} -DOCL_COMPILER_FLAGS=${OCL_COMPILER_FLAGS}
-				   -P "${CMAKE_SOURCE_DIR}/library/OCLBinaryGenerator.cmake"
+				   -P "${CMAKE_CURRENT_SOURCE_DIR}/OCLBinaryGenerator.cmake"
 				   )
 add_dependencies( OCLBinaryGenerator_GEN OCLBinaryGenerator )
 
@@ -733,7 +733,7 @@ endif()
 # if offline compilation is not chosen, bingen should not be built
 if(OPENCL_OFFLINE_BUILD_TAHITI_KERNEL OR OPENCL_OFFLINE_BUILD_HAWAII_KERNEL OR OPENCL_OFFLINE_BUILD_BONAIRE_KERNEL)
 	ExternalProject_Add( bingen
-		URL "${CMAKE_SOURCE_DIR}/library/tools/bingen"
+		URL "${CMAKE_CURRENT_SOURCE_DIR}/tools/bingen"
 		CMAKE_ARGS -DOPENCL_LIBRARIES=${OPENCL_LIBRARIES} -DOPENCL_INCLUDE_DIRS=${OPENCL_INCLUDE_DIRS}
 		INSTALL_COMMAND ""
 	)
@@ -789,21 +789,21 @@ if (LOAD_CL_FLAGS)
 add_custom_target( GEN_CLBIN )
 add_custom_command(TARGET GEN_CLBIN
                    PRE_BUILD
-				   COMMAND ${CMAKE_COMMAND} -DbingenBinaryDir=${bingenBinaryDir} -DCLTEMPLATE_PATH="${CMAKE_SOURCE_DIR}/library/blas/gens/clTemplates"
+				   COMMAND ${CMAKE_COMMAND} -DbingenBinaryDir=${bingenBinaryDir} -DCLTEMPLATE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/blas/gens/clTemplates"
 	               -DLOAD_CL_FLAGS=${LOAD_CL_FLAGS} -DTAHITI_FLAG=${OPENCL_FLAGS_REPLACED_1} -DHAWAII1_FLAG=${OPENCL_FLAGS_REPLACED_3} -DHAWAII2_FLAG=${OPENCL_FLAGS_REPLACED_5} -DBONAIRE_FLAG=${OPENCL_FLAGS_REPLACED_7}
 				   -DENV_PATH=${ENV_PATH} -DOPENCL_OFFLINE_BUILD_HAWAII_KERNEL=${OPENCL_OFFLINE_BUILD_HAWAII_KERNEL} -DOPENCL_OFFLINE_BUILD_BONAIRE_KERNEL=${OPENCL_OFFLINE_BUILD_BONAIRE_KERNEL}
 				   -DOPENCL_OFFLINE_BUILD_TAHITI_KERNEL=${OPENCL_OFFLINE_BUILD_TAHITI_KERNEL}
-				   -P "${CMAKE_SOURCE_DIR}/library/bingen.cmake"
+				   -P "${CMAKE_CURRENT_SOURCE_DIR}/bingen.cmake"
 				   )
 add_dependencies( GEN_CLBIN bingen )
 else()
 add_custom_target( GEN_CLBIN )
 add_custom_command(TARGET GEN_CLBIN
                    PRE_BUILD
-				   COMMAND ${CMAKE_COMMAND} -DbingenBinaryDir=${bingenBinaryDir} -DCLTEMPLATE_PATH="${CMAKE_SOURCE_DIR}/library/blas/gens/clTemplates"
+				   COMMAND ${CMAKE_COMMAND} -DbingenBinaryDir=${bingenBinaryDir} -DCLTEMPLATE_PATH="${CMAKE_CURRENT_SOURCE_DIR}/blas/gens/clTemplates"
 				   -DOPENCL_OFFLINE_BUILD_HAWAII_KERNEL=${OPENCL_OFFLINE_BUILD_HAWAII_KERNEL} -DOPENCL_OFFLINE_BUILD_BONAIRE_KERNEL=${OPENCL_OFFLINE_BUILD_BONAIRE_KERNEL}
 				   -DOPENCL_OFFLINE_BUILD_TAHITI_KERNEL=${OPENCL_OFFLINE_BUILD_TAHITI_KERNEL}
-				   -P "${CMAKE_SOURCE_DIR}/library/bingen.cmake"
+				   -P "${CMAKE_CURRENT_SOURCE_DIR}/bingen.cmake"
 				   )
 add_dependencies( GEN_CLBIN bingen )
 endif()
@@ -819,9 +819,9 @@ else()
 endif()
 
 add_custom_target( GENERATE_CLT
-    COMMAND ${tplgenBinaryDir}/tplgen -o ${clBLAS_BINARY_DIR}/include -i ${CMAKE_SOURCE_DIR}/library/blas/gens/clTemplates/ ${SRC_CL_TEMPLATES}
+    COMMAND ${tplgenBinaryDir}/tplgen -o ${clBLAS_BINARY_DIR}/include -i ${CMAKE_CURRENT_SOURCE_DIR}/blas/gens/clTemplates/ ${SRC_CL_TEMPLATES}
     COMMAND ${tplgenBinaryDir}/tplgen -o ${clBLAS_BINARY_DIR}/include -i ${bingenBinaryDir}/ ${SRC_CL_TEMPLATES_GEN}
-    #WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/library/blas/gens/clTemplates
+    #WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/blas/gens/clTemplates
 	WORKING_DIRECTORY ${bingenBinaryDir}
 )
 


### PR DESCRIPTION
When include clBLAS as a cmake subproject using add_subdectory(), it seems that some paths are wrong.
To fix it, I just replace ${CMAKE_SOURCE_DIR}/library with ${CMAKE_CURRENT_SOURCE_DIR} and it works.