### PR TITLE
Do not pass the -cl-std option to kernel builds

### DIFF
--- a/src/library/blas/AutoGemm/Includes.py
+++ b/src/library/blas/AutoGemm/Includes.py
@@ -272,8 +272,8 @@ class KernelSourceBuildOptions:
     kernelName = kernel.getName()
     self.incStr += "extern const char * const %s_srcBuildOptions;\n" \
         % kernelName
-    self.cppStr += "const char * const %s_srcBuildOptions = \"-cl-std=CL%s\";\n" \
-        % (kernelName, Common.getClCompilerVersion() )
+    self.cppStr += "const char * const %s_srcBuildOptions = \"\";\n" \
+        % kernelName
 
     self.incFile.write( self.incStr )
     self.incStr = ""
@@ -314,7 +314,7 @@ class KernelBinaryBuildOptions:
   def addKernel(self, kernel):
     kernelName = kernel.getName()
     self.incStr += "extern const char * const %s_binBuildOptions;\n" % kernelName
-    self.cppStr += "const char * const %s_binBuildOptions = \"-cl-std=CL%s\";\n" % (kernelName, Common.getClCompilerVersion() )
+    self.cppStr += "const char * const %s_binBuildOptions = \"\";\n" % kernelName
 
     self.incFile.write( self.incStr )
     self.incStr = ""


### PR DESCRIPTION
This pull request resolves the oft-reported error:

    OpenCL error -11 [...]
    .../clblas-2.12/src/library/blas/xgemm.cc:244: void makeGemmKernel(_cl_kernel**, cl_command_queue, const char*, const char*, const unsigned char**, size_t*, const char*): Assertion `false' failed.

This abort occurs after a `clBuildProgram()` failure in `makeGemmKernel()`. Inconveniently, the subsequent calls to `clGetProgramBuildInfo()` return an empty build log, which made this bug hard to track down.

It turns out to be pretty simple: clBLAS passes build option `-cl-std="CL1.2"` to `clBuildProgram()`. According to its [man page](https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clBuildProgram.html), this means that the OpenCL implementation will immediately fail the build if the target device is OpenCL 1.0 or 1.1. (Would've been nice if they'd at least report this in the build log ... .)

However, the `man` page also mentions that 

> If the -cl-std build option is not specified, the `CL_DEVICE_OPENCL_C_VERSION` 
> is used to select the version of OpenCL C to be used when compiling the program 
> for each device.

and since we have a handle to the device at that point, this is precisely what we want. 

I've tested against multiple OpenCL 1.1 and 1.2 backends, and it works like a charm. Best thing is that I can finally run clBLAS (and ArrayFire) on my somewhat older Radeon GPU. 
