### PR TITLE
fix: add missing stdlib header includes

### DIFF
--- a/src/library/blas/gens/gemv.c
+++ b/src/library/blas/gens/gemv.c
@@ -19,6 +19,7 @@
  * gemv generator
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>

--- a/src/library/blas/gens/symv.c
+++ b/src/library/blas/gens/symv.c
@@ -19,6 +19,7 @@
  * symv generator
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
As spotted in https://github.com/Homebrew/homebrew-core/pull/154470