### PR TITLE
Update example_ctrsm.c

### DIFF
--- a/src/samples/example_ctrsm.c
+++ b/src/samples/example_ctrsm.c
@@ -81,7 +81,7 @@ int
 main(void)
 {
     cl_int err;
-    cl_platform_id platform[] = { 0, 0 };
+    cl_platform_id platform = 0;
     cl_device_id device = 0;
     cl_context_properties props[3] = { CL_CONTEXT_PLATFORM, 0, 0 };
     cl_context ctx = 0;
@@ -91,13 +91,13 @@ main(void)
     int ret = 0;
 
     /* Setup OpenCL environment. */
-    err = clGetPlatformIDs(sizeof( platform ), &platform, NULL);
+    err = clGetPlatformIDs(1, &platform, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetPlatformIDs() failed with %d\n", err );
         return 1;
     }
 
-    err = clGetDeviceIDs(platform[0], CL_DEVICE_TYPE_CPU, 1, &device, NULL);
+    err = clGetDeviceIDs(platform, CL_DEVICE_TYPE_CPU, 1, &device, NULL);
     if (err != CL_SUCCESS) {
         printf( "clGetDeviceIDs() failed with %d\n", err );
         return 1;


### PR DESCRIPTION
Fixup a failure due to 

[ 16%] Building C object CMakeFiles/example_ctrsm.dir/example_ctrsm.c.o In file included from /usr/include/CL/cl.h:20,
                 from /usr/include/clBLAS.h:35,
                 from /tmp/example_ctrsm.c:25:
/usr/include/CL/cl_version.h:22:9: note: '#pragma message: cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 300 (OpenCL 3.0)'
   22 | #pragma message("cl_version.h: CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 300 (OpenCL 3.0)")
      |         ^~~~~~~
/tmp/example_ctrsm.c: In function 'main':
/tmp/example_ctrsm.c:95:48: error: passing argument 2 of 'clGetPlatformIDs' from incompatible pointer type [-Wincompatible-pointer-types]
   95 |     err = clGetPlatformIDs(sizeof( platform ), &platform, NULL);
      |                                                ^~~~~~~~~
      |                                                |
      |                                                struct _cl_platform_id ***
/usr/include/CL/cl.h:956:35: note: expected 'struct _cl_platform_id **' but argument is of type 'struct _cl_platform_id ***'
  956 |                  cl_platform_id * platforms,
      |                  ~~~~~~~~~~~~~~~~~^~~~~~~~~
/tmp/example_ctrsm.c:114:5: warning: 'clCreateCommandQueue' is deprecated [-Wdeprecated-declarations]
  114 |     queue = clCreateCommandQueue(ctx, device, 0, &err);
      |     ^~~~~
/usr/include/CL/cl.h:1914:1: note: declared here
 1914 | clCreateCommandQueue(cl_context                     context,
      | ^~~~~~~~~~~~~~~~~~~~