### PR TITLE
Update example_csscal.c

### DIFF
--- a/src/library/blas/gens/gemv.c
+++ b/src/library/blas/gens/gemv.c
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <math.h>
 #include <clblas_stddef.h>

--- a/src/library/blas/gens/symv.c
+++ b/src/library/blas/gens/symv.c
@@ -21,6 +21,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <math.h>
 #include <clblas_stddef.h>

--- a/src/samples/example_cher.c
+++ b/src/samples/example_cher.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* Include CLBLAS header. It automatically includes needed OpenCL header,

--- a/src/samples/example_csscal.c
+++ b/src/samples/example_csscal.c
@@ -16,6 +16,8 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_isamax.c
+++ b/src/samples/example_isamax.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_sasum.c
+++ b/src/samples/example_sasum.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_saxpy.c
+++ b/src/samples/example_saxpy.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_scopy.c
+++ b/src/samples/example_scopy.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_sdot.c
+++ b/src/samples/example_sdot.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_sger.c
+++ b/src/samples/example_sger.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_snrm2.c
+++ b/src/samples/example_snrm2.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_srot.c
+++ b/src/samples/example_srot.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_srotm.c
+++ b/src/samples/example_srotm.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_sscal.c
+++ b/src/samples/example_sscal.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 

--- a/src/samples/example_sswap.c
+++ b/src/samples/example_sswap.c
@@ -16,6 +16,7 @@
 
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <math.h>
 


### PR DESCRIPTION
with gcc-14 this warning becomes a failure

 90s /tmp/autopkgtest.g0L4Ek/autopkgtest_tmp/example_csscal.c: In function ‘main’:
 90s /tmp/autopkgtest.g0L4Ek/autopkgtest_tmp/example_csscal.c:67:26: error: implicit declaration of function ‘abs’ [-Wimplicit-function-declaration]
 90s    67 |     int lenX = 1 + (N-1)*abs(incx);
 90s       |                          ^~~
 90s /tmp/autopkgtest.g0L4Ek/autopkgtest_tmp/example_csscal.c:26:1: note: include ‘<stdlib.h>’ or provide a declaration of ‘abs’
 90s    25 | #include <clBLAS.h>
 90s   +++ |+#include <stdlib.h>
 90s    26 | 
 90s /tmp/autopkgtest.g0L4Ek/autopkgtest_tmp/example_csscal.c:89:5: warning: ‘clCreateCommandQueue’ is deprecated [-Wdeprecated-declarations]
 90s    89 |     queue = clCreateCommandQueue(ctx, device, 0, &err);
 90s       |     ^~~~~